### PR TITLE
feat : 회원정보 중 한줄소개 설정/수정/삭제 로직 구현

### DIFF
--- a/ddv/src/main/java/community/ddv/controller/UserController.java
+++ b/ddv/src/main/java/community/ddv/controller/UserController.java
@@ -60,4 +60,14 @@ public class UserController {
     userService.updateAccount(email, accountUpdateDto);
     return ResponseEntity.ok().build();
   }
+
+  @PutMapping("/me/intro")
+  public ResponseEntity<Void> updateIntro(
+      @AuthenticationPrincipal UserDetails userDetails,
+      @RequestBody AccountUpdateDto accountUpdateDto
+  ) {
+    String email = userDetails.getUsername();
+    userService.updateOneLineIntro(email, accountUpdateDto);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/ddv/src/main/java/community/ddv/dto/UserDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/UserDTO.java
@@ -52,6 +52,8 @@ public class UserDTO {
 
     private String newPassword;
     private String newConfirmPassword;
+
+    private String oneLineIntro;
   }
 
 

--- a/ddv/src/main/java/community/ddv/entity/User.java
+++ b/ddv/src/main/java/community/ddv/entity/User.java
@@ -34,6 +34,7 @@ public class User {
   private Role role;
 
   private String profileImageUrl;
+  private String oneLineIntroduction;
 
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;

--- a/ddv/src/main/java/community/ddv/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/service/UserService.java
@@ -202,5 +202,39 @@ public class UserService {
     String regex = "\\w{8,}";
     return Pattern.compile(regex).matcher(password).matches();
   }
+
+  /**
+   * 한줄소개 설정/수정/삭제
+   * @param accountUpdateDto
+   */
+  @Transactional
+  public void updateOneLineIntro(String email, AccountUpdateDto accountUpdateDto) {
+    log.info("한줄소개 수정 시도 : {}", email);
+
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new DeepdiviewException(ErrorCode.USER_NOT_FOUND));
+
+    String newOneLineIntro = accountUpdateDto.getOneLineIntro();
+
+    // 기존의 한줄소개가 없었던 경우
+    if (user.getOneLineIntroduction() == null) {
+      if (!newOneLineIntro.isEmpty()) {
+        user.setOneLineIntroduction(newOneLineIntro);
+        log.info("한줄소개 설정 완료");
+      }
+    } else {
+      // 기존의 한줄 소개가 존재하는 경우
+      if (newOneLineIntro.isEmpty()) {
+        user.setOneLineIntroduction(null);
+        log.info("한줄소개 삭제 완료");
+      } else {
+        user.setOneLineIntroduction(newOneLineIntro);
+        log.info("한줄소개 수정 완료");
+      }
+    }
+    user.setUpdatedAt(LocalDateTime.now());
+    userRepository.save(user);
+  }
+
 }
 


### PR DESCRIPTION
# [변경사항]

기존에 한줄소개가 없었던 경우
- 새롭게 설정됨

기존에 한줄소개가 있었던 경우
- 다른 한줄소개로 수정 가능
- 공백으로 둘 경우, 삭제됨


# [이후 예정 작업]
1. 넷플릭스 내 인기도 기준 탑20개의 영화 조회
2. 특정 단어로 검색시, 그 단어를 포함한 영화 리스트 조회
3. 특정 영어 제목 검색시, 영화 상세 정보 조회
