### PR TITLE
Feat : 인기도 상위 20위 영화 리스트 조회, 영화 제목으로 세부정보 검색, 특정 영화 세부정보 조회 로직 구현, 장르정보 반환형 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
       "/api/users/signup",
       "/api/users/login",
       "/api/fetch/genres",
-      "/api/fetch/movies"
+      "/api/fetch/movies",
+      "/api/movies/**"
   };
 
   @Bean

--- a/ddv/src/main/java/community/ddv/constant/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/constant/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
   NOT_VALID_PASSWORD("비밀번호가 일치하지 않습니다. 비밀번호를 다시 확인해주세요", HttpStatus.BAD_REQUEST),
   NOT_ENOUGH_PASSWORD("비밀번호는 8자 이상으로 설정해야 합니다.", HttpStatus.BAD_REQUEST),
   USER_NOT_FOUND("존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-  INVALID_REFRESH_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST);
+  INVALID_REFRESH_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST),
+  MOVIE_NOT_FOUND("존재하지 않는 영화입니다.", HttpStatus.NOT_FOUND);
 
   private final String description;
   private final HttpStatus httpStatus;

--- a/ddv/src/main/java/community/ddv/controller/MovieController.java
+++ b/ddv/src/main/java/community/ddv/controller/MovieController.java
@@ -1,11 +1,37 @@
 package community.ddv.controller;
 
+import community.ddv.dto.MovieDTO;
+import community.ddv.service.MovieService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/movies")
 public class MovieController {
 
+  private final MovieService movieService;
 
+  @GetMapping("/popularity/top20")
+  public ResponseEntity<List<MovieDTO>> showTop20Movie() {
+    List<MovieDTO> top20Movies = movieService.getTop20Movies();
+    return ResponseEntity.ok(top20Movies);
+  }
+
+  @GetMapping("/search/list")
+  public ResponseEntity<List<MovieDTO>> getMoviesByTitle(@RequestParam("title") String title) {
+    List<MovieDTO> movies = movieService.searchMoviesByTitle(title);
+    return ResponseEntity.ok(movies);
+  }
+
+  @GetMapping("/search")
+  public ResponseEntity<MovieDTO> getMovieByTitle(@RequestParam("title") String title) {
+    MovieDTO movie = movieService.getMovieInfoByTitle(title);
+    return ResponseEntity.ok(movie);
+  }
 }

--- a/ddv/src/main/java/community/ddv/controller/MovieController.java
+++ b/ddv/src/main/java/community/ddv/controller/MovieController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,9 +30,9 @@ public class MovieController {
     return ResponseEntity.ok(movies);
   }
 
-  @GetMapping("/search")
-  public ResponseEntity<MovieDTO> getMovieByTitle(@RequestParam("title") String title) {
-    MovieDTO movie = movieService.getMovieInfoByTitle(title);
-    return ResponseEntity.ok(movie);
+  @GetMapping("/{movieId}")
+  public ResponseEntity<MovieDTO> getMovieDetail(@PathVariable Long movieId) {
+    MovieDTO movieDetails = movieService.getMovieDetailsById(movieId);
+    return ResponseEntity.ok(movieDetails);
   }
 }

--- a/ddv/src/main/java/community/ddv/dto/MovieDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/MovieDTO.java
@@ -3,10 +3,12 @@ package community.ddv.dto;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
+@Builder
 public class MovieDTO {
 
   private Long id;       // tmdb에서 제공하는 id

--- a/ddv/src/main/java/community/ddv/dto/MovieDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/MovieDTO.java
@@ -20,5 +20,6 @@ public class MovieDTO {
   private String poster_path;     // 포스터 url
   private String backdrop_path;   // 백드롭이미지 url
   private List<Long> genre_ids;   // 장르 아이디 리스트
+  private List<String> genre_names; // 장르 이름 리스트
 
 }

--- a/ddv/src/main/java/community/ddv/entity/Movie.java
+++ b/ddv/src/main/java/community/ddv/entity/Movie.java
@@ -26,7 +26,7 @@ public class Movie {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id; // 본 서비스에서 사용하는 id
 
-  private Long timdbId;       // tmdb에서 제공하는 id
+  private Long tmdbId;       // tmdb에서 제공하는 id
   private String title;          // 제목
   private String originalTitle;  // 원어 제목
 

--- a/ddv/src/main/java/community/ddv/entity/MovieGenre.java
+++ b/ddv/src/main/java/community/ddv/entity/MovieGenre.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class MovieGenre {
 
   @Id

--- a/ddv/src/main/java/community/ddv/repository/MovieRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/MovieRepository.java
@@ -1,10 +1,27 @@
 package community.ddv.repository;
 
 import community.ddv.entity.Movie;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MovieRepository extends JpaRepository<Movie, Long> {
+
+  // 넷플 내 인기도 상위 20개의 영화 정보 조회 (페이징처리)
+  Page<Movie> findTop20ByOrderByPopularityDesc(Pageable pageable);
+
+  // 특정 단어가 포함된 영화 정보 리스트 조회(공백 무시)
+  @Query("SELECT m FROM Movie m WHERE REPLACE(m.title, ' ', '') LIKE CONCAT('%', REPLACE(:title, ' ', ''), '%') ORDER BY m.popularity DESC")
+  List<Movie> findByTitleFlexible(@Param("title") String title);
+
+  // 특정 영화 세부정보 조회 (공백 무시)
+  @Query("SELECT m FROM Movie m WHERE REPLACE(m.title, ' ', '') LIKE CONCAT('%', REPLACE(:title, ' ', ''), '%') ORDER BY m.popularity DESC")
+  Optional<Movie> findByTitle(@Param("title") String title);
 
 }

--- a/ddv/src/main/java/community/ddv/service/MovieApiService.java
+++ b/ddv/src/main/java/community/ddv/service/MovieApiService.java
@@ -75,7 +75,7 @@ public class MovieApiService {
 
   private Movie toEntity(MovieDTO movieDTO) {
     Movie movie = Movie.builder()
-        .timdbId(movieDTO.getId())
+        .tmdbId(movieDTO.getId())
         .title(movieDTO.getTitle())
         .originalTitle(movieDTO.getOriginal_title())
         .overview(movieDTO.getOverview())

--- a/ddv/src/main/java/community/ddv/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/service/MovieService.java
@@ -53,34 +53,33 @@ public class MovieService {
   }
 
   /**
-   * 특정 영화의 세부정보 조회 _ 공백 무시 가능
-   * @param title
+   * 특정 영화 id로 해당 영화의 세부정보 조회
+   * @param movieId
    */
-  public MovieDTO getMovieInfoByTitle(String title) {
-    Optional<Movie> movie = movieRepository.findByTitle(title);
-    if (movie.isPresent()) {
-      movie.ifPresent(this::convertToDTO);
-    } else {
-      throw new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND);
-    }
-    return convertToDTO(movie.get());
+  public MovieDTO getMovieDetailsById(Long movieId) {
+    return movieRepository.findById(movieId)
+        .map(this::convertToDTO)
+        .orElseThrow(() -> new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND));
   }
 
 
   private MovieDTO convertToDTO(Movie movie) {
 
-    return new MovieDTO(
-        movie.getId(),
-        movie.getTitle(),
-        movie.getOriginalTitle(),
-        movie.getOverview(),
-        movie.getReleaseDate(),
-        movie.getPopularity(),
-        movie.getPosterPath(),
-        movie.getBackdropPath(),
-        movie.getMovieGenres().stream()
+    return MovieDTO.builder()
+        .id(movie.getTmdbId())
+        .title(movie.getTitle())
+        .original_title(movie.getOriginalTitle())
+        .overview(movie.getOverview())
+        .release_date(movie.getReleaseDate())
+        .popularity(movie.getPopularity())
+        .poster_path(movie.getPosterPath())
+        .backdrop_path(movie.getBackdropPath())
+        .genre_ids(movie.getMovieGenres().stream()
             .map(movieGenre -> movieGenre.getGenre().getId())
-            .collect(Collectors.toList())
-    );
+            .collect(Collectors.toList()))
+        .genre_names(movie.getMovieGenres().stream()
+            .map(movieGenre -> movieGenre.getGenre().getName())
+            .collect(Collectors.toList()))
+        .build();
   }
 }

--- a/ddv/src/main/java/community/ddv/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/service/MovieService.java
@@ -1,0 +1,86 @@
+package community.ddv.service;
+
+import community.ddv.constant.ErrorCode;
+import community.ddv.dto.MovieDTO;
+import community.ddv.entity.Movie;
+import community.ddv.exception.DeepdiviewException;
+import community.ddv.repository.MovieRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MovieService {
+
+  private final MovieRepository movieRepository;
+
+  /**
+   * 넷플릭스 내 인기도 탑 20 영화 세부정보 조회
+   */
+  public List<MovieDTO> getTop20Movies() {
+    Pageable pageable = PageRequest.of(0, 20);
+    Page<Movie> top20Movies = movieRepository.findTop20ByOrderByPopularityDesc(pageable);
+    return top20Movies.stream()
+        .map(this::convertToDTO)
+        .collect(Collectors.toList());
+  }
+
+
+  /**
+   * 영화 제목으로 해당 영화의 세부정보 조회 _ 공백 무시 가능 & 특정 글자가 포함되는 조회됨 & 넷플 인기도 순 정렬
+   * @param title
+   */
+  public List<MovieDTO> searchMoviesByTitle(String title) {
+    try {
+      List<Movie> movies = movieRepository.findByTitleFlexible(title);
+      if (movies.isEmpty()) {
+        throw new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND);
+      }
+      return movies.stream()
+          .map(this::convertToDTO)
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new RuntimeException("영화 정보 조회 중 오류 발생");
+    }
+  }
+
+  /**
+   * 특정 영화의 세부정보 조회 _ 공백 무시 가능
+   * @param title
+   */
+  public MovieDTO getMovieInfoByTitle(String title) {
+    Optional<Movie> movie = movieRepository.findByTitle(title);
+    if (movie.isPresent()) {
+      movie.ifPresent(this::convertToDTO);
+    } else {
+      throw new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND);
+    }
+    return convertToDTO(movie.get());
+  }
+
+
+  private MovieDTO convertToDTO(Movie movie) {
+
+    return new MovieDTO(
+        movie.getId(),
+        movie.getTitle(),
+        movie.getOriginalTitle(),
+        movie.getOverview(),
+        movie.getReleaseDate(),
+        movie.getPopularity(),
+        movie.getPosterPath(),
+        movie.getBackdropPath(),
+        movie.getMovieGenres().stream()
+            .map(movieGenre -> movieGenre.getGenre().getId())
+            .collect(Collectors.toList())
+    );
+  }
+}


### PR DESCRIPTION
# [변경사항]

1. 넷플릭스 내 인기도 탑 20개의 영화 세부 정보를 조회할 수 있습니다. 
우리서비스 내 평점은 아직 넣지 않은 상태입니다. 

2. 영화 제목 중 특정 단어로 검색시, 해당 단어가 포함된 제목을 가진 영화들의 세부 정보를 리스트로 조회할 수 있습니다. 
 공백(띄어쓰기) 무시 가능 & 특정 글자가 포함되는 조회됨 & 넷플 인기도 순 정렬
 우리 서비스 내 리뷰 기능을 아직 구현하지 않았기 때문에 추후 삽입할 예정입니다. 

3. Tmdb가 제공한 영화 Id로 특정 영화의 세부정보를 조회할 수 있습니다. 

4. 장르정보가 id값만 나오는 것이 아니라 실제 장르명도 함께 조회되도록 수정했습니다.  

# [테스트 케이스]

1. 특정 단어가 포함된 영화 제목 검색의 경우, 띄어쓰기를 무시하도록 함 
'존 윅' 혹은 '존윅' 이렇게 검색해도 동일한 결과 반환 

# [이후 예정 작업]
- [ ]  배포 -> swagger 도입 -> API 명세서 공유
- [X] 상단의 3번 재작업
