### PR TITLE
Fix : 특정 영화 검색시 넣어야 하는 id 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/repository/MovieRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/MovieRepository.java
@@ -24,4 +24,5 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
   @Query("SELECT m FROM Movie m WHERE REPLACE(m.title, ' ', '') LIKE CONCAT('%', REPLACE(:title, ' ', ''), '%') ORDER BY m.popularity DESC")
   Optional<Movie> findByTitle(@Param("title") String title);
 
+  Optional<Movie> findByTmdbId(Long tmdbId);
 }

--- a/ddv/src/main/java/community/ddv/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/service/MovieService.java
@@ -54,10 +54,10 @@ public class MovieService {
 
   /**
    * 특정 영화 id로 해당 영화의 세부정보 조회
-   * @param movieId
+   * @param tmdbId
    */
-  public MovieDTO getMovieDetailsById(Long movieId) {
-    return movieRepository.findById(movieId)
+  public MovieDTO getMovieDetailsById(Long tmdbId) {
+    return movieRepository.findByTmdbId(tmdbId)
         .map(this::convertToDTO)
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND));
   }


### PR DESCRIPTION
# [변경사항]

id가 두 개라 조금 헷갈리는 상황이 발생하여 DB 자체의 id가 아니라 tmdb에서 제공하는 id를 사용하는 것으로 변경


# [이후 예정 작업]
1. 리뷰 게시글 CRUD 