### PR TITLE
Feat : 인증 로직 구현 

### DIFF
--- a/ddv/build.gradle
+++ b/ddv/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/ddv/src/main/java/community/ddv/config/S3Config.java
+++ b/ddv/src/main/java/community/ddv/config/S3Config.java
@@ -1,0 +1,33 @@
+package community.ddv.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+  @Value("${cloud.aws.credentials.access-key}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.secret-key}")
+  private String secretKey;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AmazonS3 s3Client() {
+    BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    return AmazonS3ClientBuilder.standard()
+        .withRegion(region)
+        .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+        .build();
+
+  }
+
+}

--- a/ddv/src/main/java/community/ddv/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -48,6 +49,8 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(AUTH_WHITELIST).permitAll() // 로그인 없이도 할 수 있는 기능
             .requestMatchers(HttpMethod.POST, "/api/votes").hasAuthority("ADMIN") // 관리자만 투표 생성 가능
+            .requestMatchers(HttpMethod.GET, "/api/certifications/admin/**").hasAuthority("ADMIN")
+            .requestMatchers(HttpMethod.POST, "/api/certifications/admin/**").hasAuthority("ADMIN")
             .anyRequest().authenticated()
         )
         .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class) // jwt 필터

--- a/ddv/src/main/java/community/ddv/constant/CertificationStatus.java
+++ b/ddv/src/main/java/community/ddv/constant/CertificationStatus.java
@@ -1,0 +1,9 @@
+package community.ddv.constant;
+
+public enum CertificationStatus {
+
+  PENDING, // 보류
+  APPROVED, // 승인
+  REJECTED // 거절
+
+}

--- a/ddv/src/main/java/community/ddv/constant/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/constant/ErrorCode.java
@@ -24,7 +24,11 @@ public enum ErrorCode {
   ALREADY_EXIST_ADMIN("관리자는 한 명만 가능합니다.", HttpStatus.FORBIDDEN),
   ONLY_ADMIN_CAN("관리자만 할 수 있는 기능입니다.", HttpStatus.FORBIDDEN),
   INVALID_REQUEST("잘못된 요청입니다. 다시 확인해주세요", HttpStatus.BAD_REQUEST),
-  INVALID_VOTE_CREAT_DATE("투표 생성은 일,월요일에만 가능합니다.", HttpStatus.BAD_REQUEST);
+  INVALID_VOTE_CREAT_DATE("투표 생성은 일,월요일에만 가능합니다.", HttpStatus.BAD_REQUEST),
+  VOTE_NOT_FOUND("존재하지 않는 투표입니다.", HttpStatus.BAD_REQUEST),
+  CERTIFICATION_NOT_FOUND("인증요청이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+  ALREADY_APPROVED("이미 승인되었습니다.", HttpStatus.BAD_REQUEST
+  ),;
 
 
   private final String description;

--- a/ddv/src/main/java/community/ddv/constant/RejectionReason.java
+++ b/ddv/src/main/java/community/ddv/constant/RejectionReason.java
@@ -1,0 +1,9 @@
+package community.ddv.constant;
+
+public enum RejectionReason {
+
+  NONE,
+  OTHER_MOVIE_IMAGE,   // 다른 영화 사진 업로드
+  WRONG_IMAGE,         // 관계없는 사진 업로드
+  UNIDENTIFIABLE_IMAGE // 식별불가 사진 업로드
+}

--- a/ddv/src/main/java/community/ddv/controller/CertificationController.java
+++ b/ddv/src/main/java/community/ddv/controller/CertificationController.java
@@ -1,0 +1,63 @@
+package community.ddv.controller;
+
+import community.ddv.constant.RejectionReason;
+import community.ddv.dto.CertificationDTO;
+import community.ddv.dto.CertificationDTO.CertificationRequestDto;
+import community.ddv.dto.CertificationDTO.CertificationResponseDto;
+import community.ddv.service.CertificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/certifications")
+@RequiredArgsConstructor
+public class CertificationController {
+
+  private final CertificationService certificationService;
+
+  @Operation(summary = "인증샷 제출", description = "파일 업로드")
+  @PostMapping
+  public ResponseEntity<CertificationResponseDto> submitCertification(
+      @RequestParam("file") MultipartFile file) throws Exception {
+    return ResponseEntity.ok(certificationService.submitCertification(file));
+  }
+
+  @Operation(summary = "인증 대기자 목록 조회", description = "관리자 전용")
+  @GetMapping("/admin/pending")
+  public ResponseEntity<Page<CertificationResponseDto>> getPendingCertifications(Pageable pageable) {
+    Page<CertificationResponseDto> certifications = certificationService.getPendingCertifications(
+        pageable);
+    return ResponseEntity.status(HttpStatus.OK).body(certifications);
+  }
+
+  @Operation(summary = "특정 인증정보 조회_인증샷 확인", description = "관리자 전용")
+  @GetMapping("/admin/{certificationId}")
+  public ResponseEntity<CertificationResponseDto> getCertificationById(
+      @PathVariable Long certificationId) {
+    CertificationResponseDto certification = certificationService.getCertification(certificationId);
+    return ResponseEntity.status(HttpStatus.OK).body(certification);
+  }
+
+  @Operation(summary = "인증 승인/거절", description = "관리자 전용. 승인 : true / 거절 : false")
+  @PostMapping("/admin/proceeding/{certificationId}")
+  public ResponseEntity<Void> proceedCertification(
+      @PathVariable Long certificationId,
+      @RequestBody CertificationRequestDto requestDto) {
+    certificationService.proceedCertification(certificationId, requestDto.isApprove(), requestDto.getRejectionReason());
+    return ResponseEntity.noContent().build();
+  }
+}
+
+

--- a/ddv/src/main/java/community/ddv/dto/CertificationDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/CertificationDTO.java
@@ -1,0 +1,20 @@
+package community.ddv.dto;
+
+import community.ddv.constant.CertificationStatus;
+import community.ddv.constant.RejectionReason;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CertificationDTO {
+
+    private Long id;
+    private Long userId;
+    private String certificationUrl;
+    private CertificationStatus status;
+    private LocalDateTime createdAt;
+    private RejectionReason rejectionReason;
+
+}

--- a/ddv/src/main/java/community/ddv/dto/CertificationDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/CertificationDTO.java
@@ -10,11 +10,25 @@ import lombok.Getter;
 @Builder
 public class CertificationDTO {
 
-    private Long id;
-    private Long userId;
-    private String certificationUrl;
-    private CertificationStatus status;
-    private LocalDateTime createdAt;
-    private RejectionReason rejectionReason;
+    @Getter
+    public static class CertificationRequestDto {
+
+        private boolean approve;
+        private RejectionReason rejectionReason;
+    }
+
+    @Getter
+    @Builder
+    public static class CertificationResponseDto {
+
+        private Long id;
+        private Long userId;
+        private String certificationUrl;
+        private CertificationStatus status;
+        private LocalDateTime createdAt;
+        private RejectionReason rejectionReason;
+    }
+
+
 
 }

--- a/ddv/src/main/java/community/ddv/entity/Certification.java
+++ b/ddv/src/main/java/community/ddv/entity/Certification.java
@@ -1,0 +1,52 @@
+package community.ddv.entity;
+
+import community.ddv.constant.CertificationStatus;
+import community.ddv.constant.RejectionReason;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class Certification {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  private String certificationUrl; // 인증샷 url
+
+  @Enumerated(EnumType.STRING)
+  private CertificationStatus status; // 인증 여부 (보류/승인/거절)
+
+  @Enumerated(EnumType.STRING)
+  private RejectionReason rejectionReason; // 인증 거절 사유
+
+  private LocalDateTime createdAt; // 인증 제출 시각
+
+  public void setStatus(CertificationStatus status, RejectionReason rejectionReason) {
+    this.status = status;
+    this.rejectionReason = rejectionReason;
+  }
+
+}

--- a/ddv/src/main/java/community/ddv/repository/CertificationRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/CertificationRepository.java
@@ -1,0 +1,15 @@
+package community.ddv.repository;
+
+import community.ddv.constant.CertificationStatus;
+import community.ddv.entity.Certification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CertificationRepository extends JpaRepository<Certification, Long> {
+
+  boolean existsByUser_IdAndStatus(Long userId, CertificationStatus status);
+  Page<Certification> findByStatus(CertificationStatus status, Pageable pageable);
+}

--- a/ddv/src/main/java/community/ddv/service/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/service/CertificationService.java
@@ -1,0 +1,132 @@
+package community.ddv.service;
+
+import community.ddv.constant.CertificationStatus;
+import community.ddv.constant.ErrorCode;
+import community.ddv.constant.RejectionReason;
+import community.ddv.dto.CertificationDTO;
+import community.ddv.dto.CertificationDTO.CertificationResponseDto;
+import community.ddv.entity.Certification;
+import community.ddv.entity.User;
+import community.ddv.exception.DeepdiviewException;
+import community.ddv.repository.CertificationRepository;
+import community.ddv.repository.UserRepository;
+import community.ddv.repository.VoteRepository;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CertificationService {
+
+  private final CertificationRepository certificationRepository;
+  private final FileStorageService fileStorageService;
+  private final UserRepository userRepository;
+  private final UserService userService;
+  private final VoteRepository voteRepository;
+
+  /**
+   * 일반사용자 _ 영화를 봤는지 인증을 위한 인증샷 제출 (특정 영화의 리뷰에 참여하기 위함)
+   * @param file
+   */
+  @Transactional
+  public CertificationResponseDto submitCertification(MultipartFile file) throws IOException {
+
+    log.info("인증샷 업로드 시도");
+    User user = userService.getLoginUser();
+
+    // 이미 인증 승인을 받은 경우, 중복 인증 불가
+    if (certificationRepository.existsByUser_IdAndStatus(user.getId(), CertificationStatus.APPROVED)) {
+      throw new DeepdiviewException(ErrorCode.ALREADY_APPROVED);
+    }
+
+    String certificationUrl = fileStorageService.uploadFile(file);
+    log.info("S3에 인증샷 업로드 완료 : {} ", certificationUrl);
+
+    Certification certification = Certification.builder()
+        .user(user)
+        .certificationUrl(certificationUrl)
+        .status(CertificationStatus.PENDING) // 기본값 : 보류
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    Certification savedCertification = certificationRepository.save(certification);
+    log.info("인증샷 업로드 성공");
+    return CertificationResponseDto.builder()
+        .id(savedCertification.getId())
+        .userId(savedCertification.getUser().getId())
+        .certificationUrl(savedCertification.getCertificationUrl())
+        .status(savedCertification.getStatus())
+        .createdAt(savedCertification.getCreatedAt())
+        .build();
+  }
+
+  /**
+   * 관리자 _ 인증 대기 목록 조회
+   * @param pageable
+   * @return
+   */
+  public Page<CertificationResponseDto> getPendingCertifications(Pageable pageable) {
+    userService.getLoginUser();
+    return certificationRepository.findByStatus(CertificationStatus.PENDING, pageable)
+        .map(certification -> CertificationResponseDto.builder()
+            .id(certification.getId())
+            .userId(certification.getUser().getId())
+            .certificationUrl(certification.getCertificationUrl())
+            .createdAt(certification.getCreatedAt())
+            .build());
+  }
+
+  /**
+   * 관리자 _ 특정 인증 정보 가져오는 메서드 (이미지 확인용)
+   * @param certificationId
+   * @return
+   */
+  public CertificationResponseDto getCertification(Long certificationId) {
+    userService.getLoginUser();
+    Certification certification = certificationRepository.findById(certificationId)
+        .orElseThrow(() -> new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND));
+
+    return CertificationResponseDto.builder()
+        .id(certificationId)
+        .userId(certification.getUser().getId())
+        .certificationUrl(certification.getCertificationUrl())
+        .createdAt(certification.getCreatedAt())
+        .status(certification.getStatus())
+        .rejectionReason(certification.getRejectionReason())
+        .build();
+  }
+
+  /**
+   * 관리자 _ 인증 처리 (승인 : true, 거절 : false) & 거절 메시지
+   * @param certificationId
+   * @param approve
+   * @param rejectionReason
+   */
+  public void proceedCertification(Long certificationId, boolean approve, RejectionReason rejectionReason) {
+    userService.getLoginUser();
+
+    Certification certification = certificationRepository.findById(certificationId)
+        .orElseThrow(() -> new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND));
+
+    certification.setStatus(approve ? CertificationStatus.APPROVED : CertificationStatus.REJECTED,
+                            approve ? RejectionReason.NONE : rejectionReason);
+    certificationRepository.save(certification);
+  }
+
+
+  /**
+   * 특정 사용자가 인증 승인을 받았는지 확인
+   */
+  public boolean isUserCertificated(Long userId) {
+    return certificationRepository.existsByUser_IdAndStatus(userId, CertificationStatus.APPROVED);
+  }
+
+}

--- a/ddv/src/main/java/community/ddv/service/FileStorageService.java
+++ b/ddv/src/main/java/community/ddv/service/FileStorageService.java
@@ -1,0 +1,64 @@
+package community.ddv.service;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FileStorageService {
+
+  private final AmazonS3 amazonS3;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  /**
+   * S3에 이미지 업로드
+   * @param file
+   */
+  public String uploadFile(MultipartFile file) throws IOException {
+
+    if (file.isEmpty()) {
+      throw new IOException("파일이 존재하지 않습니다.");
+    }
+
+    String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename(); // 고유한 파일 이름 생성
+
+    // 메타데이터 설정
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentType(file.getContentType());
+    metadata.setContentLength(file.getSize());
+
+    // S3에 파일 업로드 요청 생성
+    PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata);
+
+    try {
+      // S3에 파일 업로드
+      amazonS3.putObject(putObjectRequest);
+    } catch (AmazonServiceException e) {
+      log.error("Amazon Service Exception: {}", e.getMessage());
+      throw new IOException("S3에 파일 업로드 중 문제가 발생했습니다.");
+    }
+
+    return getImageUrl(fileName);
+  }
+
+  private String getImageUrl(String fileName) {
+    return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, fileName);
+  }
+
+
+}


### PR DESCRIPTION
# [변경사항]

1. 일반 사용자 - 영화를 봤는지 인증을 위한 인증샷 제출 (특정 영화의 리뷰에 참여하기 위함)
    -  이미 인증 승인을 받은 경우, 중복 인증이 불가합니다. 
    - 인증샷을 제출하면 기본적으로 인증 보류(PENDING)상태가 됩니다. 

2. 관리자 - 인증 대기 목록 조회
    - PENDING 상태인 인증들을 조회할 수 있습니다.  
    
3. 관리자 - 특정 인증 정보 조회 
  - 인증샷 확인용
 
 4. 관리자 - 인증 처리 (승인 : true, 거절 : false) & 거절 메시지 작성 


# [이후 예정 작업]
- 파일은 이미지만 가능하도록 수정
- 인증 보류뿐만 아니라 승인/거절된 사용자 목록도 조회되도록 추가
- 인증을 받은 사용자만 해당 주에 득표 1위한 영화에 대해 리뷰글 작성 로직 구현 