### PR TITLE
Refactor : 인증 로직 수정 보완

### DIFF
--- a/ddv/src/main/java/community/ddv/constant/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/constant/ErrorCode.java
@@ -33,7 +33,8 @@ public enum ErrorCode {
   INVALID_VOTE_PERIOD_ENDED("이미 종료된 투표입니다.", HttpStatus.BAD_REQUEST),
   INVALID_VOTE_PERIOD_NOT_STARTED("아직 진행중인 투표가 없습니다.", HttpStatus.BAD_REQUEST),
   DUPLICATION_NOT_ALLOW("한 개만 선택할 수 있습니다. ", HttpStatus.MULTIPLE_CHOICES),
-  ALREADY_EXIST_VOTE("이미 이번주에 생성한 투표가 있습니다.", HttpStatus.BAD_REQUEST);
+  ALREADY_EXIST_VOTE("이미 이번주에 생성한 투표가 있습니다.", HttpStatus.BAD_REQUEST),
+  IMAGE_FILE_ONLY("이미지 파일(jpg, jpeg, png, gif)만 업로드 가능합니다.", HttpStatus.BAD_REQUEST);
 
 
   private final String description;

--- a/ddv/src/main/java/community/ddv/controller/CertificationController.java
+++ b/ddv/src/main/java/community/ddv/controller/CertificationController.java
@@ -1,7 +1,6 @@
 package community.ddv.controller;
 
-import community.ddv.constant.RejectionReason;
-import community.ddv.dto.CertificationDTO;
+import community.ddv.constant.CertificationStatus;
 import community.ddv.dto.CertificationDTO.CertificationRequestDto;
 import community.ddv.dto.CertificationDTO.CertificationResponseDto;
 import community.ddv.service.CertificationService;
@@ -9,6 +8,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,11 +36,13 @@ public class CertificationController {
     return ResponseEntity.ok(certificationService.submitCertification(file));
   }
 
-  @Operation(summary = "인증 대기자 목록 조회", description = "관리자 전용")
-  @GetMapping("/admin/pending")
-  public ResponseEntity<Page<CertificationResponseDto>> getPendingCertifications(Pageable pageable) {
-    Page<CertificationResponseDto> certifications = certificationService.getPendingCertifications(
-        pageable);
+  @Operation(summary = "인증 목록 조회", description = "관리자 전용 - 보류, 승인, 거절 필터링 가능 | 한 페이지당 10개씩 반환 ㅣ 인증요청을 한 순서대로 정렬됩니다.")
+  @GetMapping("/admin")
+  public ResponseEntity<Page<CertificationResponseDto>> getPendingCertifications(
+      @RequestParam(required = false) CertificationStatus status,
+      @PageableDefault(size = 10, page = 0, sort = "createdAt", direction = Direction.ASC) Pageable pageable) {
+    Page<CertificationResponseDto> certifications = certificationService.getCertificationsByStatus(
+        status, pageable);
     return ResponseEntity.status(HttpStatus.OK).body(certifications);
   }
 

--- a/ddv/src/main/java/community/ddv/service/FileStorageService.java
+++ b/ddv/src/main/java/community/ddv/service/FileStorageService.java
@@ -4,12 +4,16 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import community.ddv.constant.ErrorCode;
+import community.ddv.exception.DeepdiviewException;
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -25,6 +29,9 @@ public class FileStorageService {
   @Value("${cloud.aws.region.static}")
   private String region;
 
+  // 허용된 확장자 리스트
+  private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "gif");
+
   /**
    * S3에 이미지 업로드
    * @param file
@@ -33,6 +40,11 @@ public class FileStorageService {
 
     if (file.isEmpty()) {
       throw new IOException("파일이 존재하지 않습니다.");
+    }
+
+    String fileExtension = StringUtils.getFilenameExtension(file.getOriginalFilename());
+    if (fileExtension == null || !ALLOWED_EXTENSIONS.contains(fileExtension.toLowerCase())) {
+      throw new DeepdiviewException(ErrorCode.IMAGE_FILE_ONLY);
     }
 
     String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename(); // 고유한 파일 이름 생성


### PR DESCRIPTION
# [변경사항]
1. 인증샷 업로드는 이미지 파일만 가능하도록 수정했습니다.
2. 인증 상태가 보류인 사용자만 조회하는 것이 아니라 전체, 보류, 승인, 거절 상태로 필터링하여 조회할 수 있도록 수정했습니다.

# [이후 예정 작업]
- 인증받은 사용자의 토론 게시판 