### PR TITLE
Feat : 별점 분포 조회 추가 

### DIFF
--- a/ddv/src/main/java/community/ddv/controller/UserController.java
+++ b/ddv/src/main/java/community/ddv/controller/UserController.java
@@ -85,14 +85,14 @@ public class UserController {
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "내 정보 확인", description = "닉네임, 이메일, 프로필사진, 한줄소개, 리뷰수, 댓글수")
+  @Operation(summary = "내 정보 확인", description = "닉네임, 이메일, 프로필사진, 한줄소개, 리뷰수, 댓글수, 별점 분포")
   @GetMapping("/me")
   public ResponseEntity<UserInfoDto> getMyInfo() {
     UserInfoDto userInfoDto = userService.getMyInfo();
     return ResponseEntity.ok(userInfoDto);
   }
 
-  @Operation(summary = "다른 유저 정보 확인", description = "닉네임, 프로필사진, 한줄소개, 리뷰수, 댓글수")
+  @Operation(summary = "다른 유저 정보 확인", description = "닉네임, 프로필사진, 한줄소개, 리뷰수, 댓글수, 별점 분포")
   @GetMapping("/{userId}")
   public ResponseEntity<UserInfoDto> getMyInfo(
       @PathVariable Long userId) {

--- a/ddv/src/main/java/community/ddv/dto/ReviewResponseDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/ReviewResponseDTO.java
@@ -25,6 +25,7 @@ public class ReviewResponseDTO {
   private double rating;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
+  private Integer likeCount;
 
   private List<CommentResponseDto> comments;
 }

--- a/ddv/src/main/java/community/ddv/dto/UserDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/UserDTO.java
@@ -3,6 +3,7 @@ package community.ddv.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -74,6 +75,7 @@ public class UserDTO {
     private String oneLineIntro;
     private int reviewCount; // 리뷰 작성 개수
     private int commentCount; // 댓글 작성 개수
+    private Map<Double, Long> ratingDistribution; // 별점 분포
   }
 
 

--- a/ddv/src/main/java/community/ddv/repository/ReviewRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/ReviewRepository.java
@@ -14,5 +14,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   int countByUser_Id(Long userId);
   Page<Review> findByMovie(Movie movie, Pageable pageable);
   Page<Review> findByUser_Id(Long userId, Pageable pageable);
+  List<Review> findAllByUser_Id(Long userId);
   //List<Review> findTop5ByMovieOrderByCreatedAtDesc(Movie movie);
 }

--- a/ddv/src/main/java/community/ddv/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/service/ReviewService.java
@@ -171,6 +171,7 @@ public class ReviewService {
         .rating(review.getRating())
         .createdAt(review.getCreatedAt())
         .updatedAt(review.getUpdatedAt())
+        .likeCount(review.getLikeCount())
         .build();
   }
 
@@ -184,6 +185,7 @@ public class ReviewService {
         .rating(review.getRating())
         .createdAt(review.getCreatedAt())
         .updatedAt(review.getUpdatedAt())
+        .likeCount(review.getLikeCount())
         .comments(review.getComments().stream()
             .map(this::convertToCommentDto)
             .collect(Collectors.toList()))

--- a/ddv/src/main/java/community/ddv/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/service/ReviewService.java
@@ -64,7 +64,6 @@ public class ReviewService {
     return convertToResponseDto(savedReview);
   }
 
-
   /**
    * 리뷰 삭제 _ 작성자만 가능
    * @param reviewId
@@ -85,7 +84,6 @@ public class ReviewService {
     reviewRepository.delete(review);
     log.info("리뷰 삭제 완료");
   }
-
 
   /**
    * 리뷰 수정 _ 작성자만 수정 가능, 제목 내용 별점 각각 수정 가능, 별점은 변경하지 않을 시 null로 들어가야 함
@@ -125,6 +123,11 @@ public class ReviewService {
     return convertToResponseDto(updatedReview);
   }
 
+  /**
+   * 특정 영화의 리뷰 조회
+   * @param tmdbId
+   *
+   */
   @Transactional(readOnly = true)
   public Page<ReviewResponseDTO> getReviewByMovieId(Long tmdbId, Pageable pageable) {
     log.info("특정 영화의 리뷰 조회 시도");
@@ -137,6 +140,10 @@ public class ReviewService {
     return reviews.map(this::convertToResponseDto);
   }
 
+  /**
+   * 특정 리뷰 조회
+   * @param reviewId
+   */
   @Transactional(readOnly = true)
   public ReviewResponseDTO getReviewById(Long reviewId) {
     log.info("특정 리뷰 조회 요청");
@@ -148,6 +155,11 @@ public class ReviewService {
     return convertToResponseWithCommentsDto(review);
   }
 
+  /**
+   * 특정 사용자가 작성한 리뷰 조회
+   * @param userId
+   * @return
+   */
   @Transactional(readOnly = true)
   public Page<ReviewResponseDTO> getReviewsByUserId(Long userId, Pageable pageable) {
     log.info("특정 사용자의 리뷰 내역 조회 요청");

--- a/ddv/src/main/java/community/ddv/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/service/UserService.java
@@ -9,6 +9,7 @@ import community.ddv.dto.UserDTO.LoginDto;
 import community.ddv.dto.UserDTO.SignUpDto;
 import community.ddv.dto.UserDTO.UserInfoDto;
 import community.ddv.entity.RefreshToken;
+import community.ddv.entity.Review;
 import community.ddv.entity.User;
 import community.ddv.exception.DeepdiviewException;
 import community.ddv.repository.CommentRepository;
@@ -18,8 +19,12 @@ import community.ddv.repository.UserRepository;
 import community.ddv.response.LoginResponse;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -254,13 +259,21 @@ public class UserService {
     int reviewCount = reviewRepository.countByUser_Id(user.getId());
     int commentCount = commentRepository.countByUser_Id(user.getId());
 
+    Map<Double, Long> ratingDistribution = reviewRepository.findAllByUser_Id(user.getId()).stream()
+        .map(Review::getRating)
+        .collect(Collectors.groupingBy(
+            rating -> rating,
+            Collectors.counting()
+        ));
+
     return new UserInfoDto(
         user.getNickname(),
         user.getEmail(),
         user.getProfileImageUrl(),
         user.getOneLineIntroduction(),
         reviewCount,
-        commentCount
+        commentCount,
+        ratingDistribution
     );
   }
 
@@ -278,13 +291,21 @@ public class UserService {
     int reviewCount = reviewRepository.countByUser_Id(userId);
     int commentCount = commentRepository.countByUser_Id(userId);
 
+    Map<Double, Long> ratingDistribution = reviewRepository.findAllByUser_Id(user.getId()).stream()
+        .map(Review::getRating)
+        .collect(Collectors.groupingBy(
+            rating -> rating,
+            Collectors.counting()
+        ));
+
     return new UserInfoDto(
         user.getNickname(),
         null, // 다른 사용자 정보 중 이메일은 숨김처리
         user.getProfileImageUrl(),
         user.getOneLineIntroduction(),
         reviewCount,
-        commentCount
+        commentCount,
+        ratingDistribution
     );
   }
 


### PR DESCRIPTION
# [변경사항]

1. 회원정보 조회시 별점 분포를 볼 수 있도록 추가했습니다. 
2. double 타입으로 별점을 줄 수 있도록 했기 때문에 소숫점이 그대로 response 됩니다. 
` {
"4.8" : 1, 
"1.2" : 3
}  `
3. 리뷰 조회시, 좋아요 수가 함께 반환되도록 수정했습니다. 

# [이후 예정 작업]
- 사용자가 자신이 인증 상태를 볼 수 있는 기능 추가 