### PR TITLE
Feat : 내 정보 조회시 인증상태와 거절이유 추가 & Refactor : 인증 로직 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/constant/RejectionReason.java
+++ b/ddv/src/main/java/community/ddv/constant/RejectionReason.java
@@ -2,7 +2,6 @@ package community.ddv.constant;
 
 public enum RejectionReason {
 
-  NONE,
   OTHER_MOVIE_IMAGE,   // 다른 영화 사진 업로드
   WRONG_IMAGE,         // 관계없는 사진 업로드
   UNIDENTIFIABLE_IMAGE // 식별불가 사진 업로드

--- a/ddv/src/main/java/community/ddv/dto/UserDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/UserDTO.java
@@ -1,11 +1,15 @@
 package community.ddv.dto;
 
+import community.ddv.constant.CertificationStatus;
+import community.ddv.constant.RejectionReason;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.Map;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class UserDTO {
 
@@ -67,6 +71,8 @@ public class UserDTO {
 
   @Getter
   @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
   public static class UserInfoDto {
 
     private String nickname;
@@ -76,6 +82,7 @@ public class UserDTO {
     private int reviewCount; // 리뷰 작성 개수
     private int commentCount; // 댓글 작성 개수
     private Map<Double, Long> ratingDistribution; // 별점 분포
+    private CertificationStatus certificationStatus; // 인증 상태
   }
 
 

--- a/ddv/src/main/java/community/ddv/dto/UserDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/UserDTO.java
@@ -62,12 +62,6 @@ public class UserDTO {
     private String oneLineIntro;
   }
 
-  @Getter
-  public static class AdminDto{
-
-    private String email;
-    private String password;
-  }
 
   @Getter
   @AllArgsConstructor
@@ -83,6 +77,7 @@ public class UserDTO {
     private int commentCount; // 댓글 작성 개수
     private Map<Double, Long> ratingDistribution; // 별점 분포
     private CertificationStatus certificationStatus; // 인증 상태
+    private RejectionReason rejectionReason; // 인증 거절 사유
   }
 
 

--- a/ddv/src/main/java/community/ddv/entity/Certification.java
+++ b/ddv/src/main/java/community/ddv/entity/Certification.java
@@ -23,7 +23,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 @Getter
-@Setter
 public class Certification {
 
   @Id
@@ -48,5 +47,6 @@ public class Certification {
     this.status = status;
     this.rejectionReason = rejectionReason;
   }
+
 
 }

--- a/ddv/src/main/java/community/ddv/repository/CertificationRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/CertificationRepository.java
@@ -2,6 +2,7 @@ package community.ddv.repository;
 
 import community.ddv.constant.CertificationStatus;
 import community.ddv.entity.Certification;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,6 @@ public interface CertificationRepository extends JpaRepository<Certification, Lo
   @Modifying
   @Query("UPDATE Certification c SET c.status = NULL")
   int resetAllCertifications();
+
+  Optional<Certification> findByUser_Id(Long userId);
 }

--- a/ddv/src/main/java/community/ddv/service/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/service/CertificationService.java
@@ -65,21 +65,6 @@ public class CertificationService {
         .build();
   }
 
-//  /**
-//   * 관리자 _ 인증 대기 목록 조회
-//   * @param pageable
-//   * @return
-//   */
-//  public Page<CertificationResponseDto> getPendingCertifications(Pageable pageable) {
-//    userService.getLoginUser();
-//    return certificationRepository.findByStatus(CertificationStatus.PENDING, pageable)
-//        .map(certification -> CertificationResponseDto.builder()
-//            .id(certification.getId())
-//            .userId(certification.getUser().getId())
-//            .certificationUrl(certification.getCertificationUrl())
-//            .createdAt(certification.getCreatedAt())
-//            .build());
-//  }
 
   /**
    * 관리자 _ 인증 목록 조회 (인증 상태에 따른 필터링 가능)
@@ -146,10 +131,13 @@ public class CertificationService {
 
     Certification certification = certificationRepository.findById(certificationId)
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND));
-
     log.info("인증 상태 : {}", certification.getStatus());
-    certification.setStatus(approve ? CertificationStatus.APPROVED : CertificationStatus.REJECTED,
-                            approve ? RejectionReason.NONE : rejectionReason);
+
+    if (approve) {
+      certification.setStatus(CertificationStatus.APPROVED, null);
+    } else {
+      certification.setStatus(CertificationStatus.REJECTED, rejectionReason);
+    }
     log.info("인증 상태 변경 : {}", certification.getStatus());
     certificationRepository.save(certification);
   }

--- a/ddv/src/main/java/community/ddv/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/service/UserService.java
@@ -1,6 +1,7 @@
 package community.ddv.service;
 
 import community.ddv.component.JwtProvider;
+import community.ddv.constant.CertificationStatus;
 import community.ddv.constant.ErrorCode;
 import community.ddv.constant.Role;
 import community.ddv.dto.UserDTO.AccountDeleteDto;
@@ -278,6 +279,8 @@ public class UserService {
         .commentCount(commentCount)
         .ratingDistribution(ratingDistribution)
         .certificationStatus(certification != null ? certification.getStatus() : null)
+        .rejectionReason(certification != null && certification.getStatus() == CertificationStatus.REJECTED
+        ? certification.getRejectionReason() : null)
     .build();
   }
 

--- a/ddv/src/main/java/community/ddv/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/service/UserService.java
@@ -8,10 +8,12 @@ import community.ddv.dto.UserDTO.AccountUpdateDto;
 import community.ddv.dto.UserDTO.LoginDto;
 import community.ddv.dto.UserDTO.SignUpDto;
 import community.ddv.dto.UserDTO.UserInfoDto;
+import community.ddv.entity.Certification;
 import community.ddv.entity.RefreshToken;
 import community.ddv.entity.Review;
 import community.ddv.entity.User;
 import community.ddv.exception.DeepdiviewException;
+import community.ddv.repository.CertificationRepository;
 import community.ddv.repository.CommentRepository;
 import community.ddv.repository.RefreshTokenRepository;
 import community.ddv.repository.ReviewRepository;
@@ -19,11 +21,9 @@ import community.ddv.repository.UserRepository;
 import community.ddv.response.LoginResponse;
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +46,7 @@ public class UserService {
   private final ReviewRepository reviewRepository;
   private final CommentRepository commentRepository;
   private final FileStorageService fileStorageService;
+  private final CertificationRepository certificationRepository;
 
   /**
    * 회원가입
@@ -266,15 +267,18 @@ public class UserService {
             Collectors.counting()
         ));
 
-    return new UserInfoDto(
-        user.getNickname(),
-        user.getEmail(),
-        user.getProfileImageUrl(),
-        user.getOneLineIntroduction(),
-        reviewCount,
-        commentCount,
-        ratingDistribution
-    );
+    Certification certification = certificationRepository.findByUser_Id(user.getId()).orElse(null);
+
+    return UserInfoDto.builder()
+        .nickname(user.getNickname())
+        .email((user.getEmail()))
+        .profileImageUrl(user.getProfileImageUrl())
+        .oneLineIntro(user.getOneLineIntroduction())
+        .reviewCount(reviewCount)
+        .commentCount(commentCount)
+        .ratingDistribution(ratingDistribution)
+        .certificationStatus(certification != null ? certification.getStatus() : null)
+    .build();
   }
 
   /**
@@ -298,15 +302,14 @@ public class UserService {
             Collectors.counting()
         ));
 
-    return new UserInfoDto(
-        user.getNickname(),
-        null, // 다른 사용자 정보 중 이메일은 숨김처리
-        user.getProfileImageUrl(),
-        user.getOneLineIntroduction(),
-        reviewCount,
-        commentCount,
-        ratingDistribution
-    );
+    return UserInfoDto.builder()
+        .nickname(user.getNickname())
+        .profileImageUrl(user.getProfileImageUrl())
+        .oneLineIntro(user.getOneLineIntroduction())
+        .reviewCount(reviewCount)
+        .commentCount(commentCount)
+        .ratingDistribution(ratingDistribution)
+        .build();
   }
 
   // 로그인 여부 확인 메서드


### PR DESCRIPTION
# [변경사항]

1. 내 정보를 조회할 때 인증상태가 함께 조회되도록 추가했습니다. 
    - 타인의 정보를 조회할 때는 response 되지 않습니다. 
 2. 관리자 인증 처리 중 승인의 경우, 요청 바디에 true만 넣으면 됩니다. 
     - 거절시에는 false와 거절 이유를 함께 적어야 합니다. 
 3. 내 정보 조회시 인증이 거절되었을 경우, 거절사유가 함께 조회됩니다.
     - 승인된 상태의 경우, null로 반환됩니다. 

# [이후 예정 작업]

- [X] 관리자 인증 처리 중 승인의 경우, rejectionReason을 넣지 않아도 되도록 수정해보기 -> 완료!
  - 현재는 승인의 경우에도 NONE을 적어야 함. 불필요한 요청바디인 것 같아서 수정해보겠습니다. 
  - 이에 따라 내 정보 조회시 거절 상태가 뜨면 거절 사유도 함께 response 될 수 있도록 수정 