### PR TITLE
Feat : 영화정보 API콜 스케줄링

### DIFF
--- a/ddv/src/main/java/community/ddv/entity/Movie.java
+++ b/ddv/src/main/java/community/ddv/entity/Movie.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @NoArgsConstructor
@@ -35,6 +36,7 @@ public class Movie {
   private String overview;       // 즐거리
 
   private LocalDate releaseDate; // 개봉일
+  @Setter
   private Double popularity;     // 인기도
   private String posterPath;     // 포스터 url
   private String backdropPath;   // 백드롭이미지 url


### PR DESCRIPTION
# [변경사항]

1. API콜 해오는 URL 변경
    - 처음에는 인기도 순으로 정렬한 상태로 가져와서 저장했으나, 주마다 스케줄링 돌릴 때마다 DB가 전체적으로 바뀌면서 다른 기능들에 영향을 미칠 수 있겠다는 생각이 들어 정렬없이 저장해두고 코드를 통해 정렬하는 것으로 변경  
2. 인증상태는 0시 0분 0초에, 영화정보는 0시 0분 15초에 스케줄링이 돌아갑니다. 
    - 함께 돌릴 시, 문제가 생길 수 있기 때문. 
    - 영화정보가 느리게 업데이트 될 수 있어 인증상태부터 초기화합니다. 
    
# [이후 예정 작업]
