### PR TITLE
Feat & chore : 영화 API 콜 수정 & 스케줄링 로직 분리

### DIFF
--- a/ddv/src/main/java/community/ddv/component/Scheduler.java
+++ b/ddv/src/main/java/community/ddv/component/Scheduler.java
@@ -1,0 +1,24 @@
+package community.ddv.component;
+
+import community.ddv.service.MovieApiService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class Scheduler {
+
+  private final MovieApiService movieApiService;
+
+  // 매주 월요일 0시 0분 15초에 영화 데이터 업데이트
+  @Scheduled(cron = "15 0 0 * * MON")
+  public void updateMovieApi() {
+    log.info("영화정보 업데이트를 시작합니다.");
+    movieApiService.fetchAndSaveMovies();
+    log.info("영화정보 업데이트를 완료했습니다.");
+  }
+
+}

--- a/ddv/src/main/java/community/ddv/entity/Movie.java
+++ b/ddv/src/main/java/community/ddv/entity/Movie.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -28,6 +29,7 @@ public class Movie {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id; // 본 서비스에서 사용하는 id
 
+  @Column(unique = true, nullable = false)
   private Long tmdbId;       // tmdb에서 제공하는 id
   private String title;          // 제목
   private String originalTitle;  // 원어 제목
@@ -49,7 +51,14 @@ public class Movie {
     movieGenres.add(movieGenre);
   }
 
+  @Setter
+  private boolean isAvailable = true; // 넷플에서 제공중인지 여부 (기본값 true)
+
+  public void changeAsUnavailable() {
+    this.isAvailable = false;
+  }
+
   @OneToMany(mappedBy = "movie", cascade = CascadeType.ALL)
-  private List<VoteMovie> voteMovies;
+  private List<VoteMovie> voteMovies = new ArrayList<>();
 
 }


### PR DESCRIPTION
# [변경사항]

1. 넷플에서 내려가거나 새로 올라오는 영화가 있을 수 있기 때문에 이에 대한 코드 추가 
(내려갈 시, isAvailable = false로 바뀌고, DB에서는 삭제되지 않습니다. 리뷰가 함께 삭제 되기 때문)
2. 스케줄링이 돌아갈 때마다 기존에 존재하던 영화의 경우, 인기도만 새로 set 
3. 스케줄링 로직을 API 콜 로직과 분리

# [이후 예정 작업]
- 이번주 토론영화 ID (= 지난주 투표 1위영화) 조회 추가