### PR TITLE
Feat : 알림 기능 구현

### DIFF
--- a/ddv/src/main/java/community/ddv/constant/NotificationType.java
+++ b/ddv/src/main/java/community/ddv/constant/NotificationType.java
@@ -1,0 +1,18 @@
+package community.ddv.constant;
+
+public enum NotificationType {
+
+  COMMENT_ADDED("내 리뷰에 새 댓글이 달렸습니다."),
+  CERTIFICATION_APPROVED("인증이 승인되었습니다."),
+  CERTIFICATION_REJECTED("인증이 거절되었습니다.");
+
+  private final String message;
+
+  NotificationType(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/ddv/src/main/java/community/ddv/constant/NotificationType.java
+++ b/ddv/src/main/java/community/ddv/constant/NotificationType.java
@@ -1,10 +1,12 @@
 package community.ddv.constant;
 
+import lombok.Getter;
+
+@Getter
 public enum NotificationType {
 
   COMMENT_ADDED("내 리뷰에 새 댓글이 달렸습니다."),
-  CERTIFICATION_APPROVED("인증이 승인되었습니다."),
-  CERTIFICATION_REJECTED("인증이 거절되었습니다.");
+  CERTIFICATION_RESULT("인증 결과를 확인하세요.");
 
   private final String message;
 
@@ -12,7 +14,4 @@ public enum NotificationType {
     this.message = message;
   }
 
-  public String getMessage() {
-    return message;
-  }
 }

--- a/ddv/src/main/java/community/ddv/controller/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/controller/NotificationController.java
@@ -1,0 +1,44 @@
+package community.ddv.controller;
+
+import community.ddv.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  // 클라이언트가 SSE 연결 구독
+  @GetMapping(value = "/subscribe/{userId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public ResponseEntity<SseEmitter> subscribe(@PathVariable Long userId) {
+    SseEmitter emitter = new SseEmitter(300_000L); // 타임아웃 5분
+
+    notificationService.subscribe(userId, emitter);
+    return ResponseEntity.ok(emitter);
+  }
+
+  // 리뷰에 댓글 달렸을 시 알림 전송
+  @PostMapping("/comment/{userId}/{reviewId}")
+  public ResponseEntity<Void> commentNotification(@PathVariable Long userId, @PathVariable Long reviewId) {
+    notificationService.commentAdded(userId, reviewId);
+    return ResponseEntity.ok().build();
+  }
+
+  // 인증 승인/거절 시 알림 전송
+  @PostMapping("certification/{userId}")
+  public ResponseEntity<Void> certificationNotification(@PathVariable Long userId) {
+    notificationService.certificateResult(userId);
+    return ResponseEntity.ok().build();
+  }
+
+}

--- a/ddv/src/main/java/community/ddv/controller/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/controller/NotificationController.java
@@ -6,7 +6,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -25,20 +24,6 @@ public class NotificationController {
 
     notificationService.subscribe(userId, emitter);
     return ResponseEntity.ok(emitter);
-  }
-
-  // 리뷰에 댓글 달렸을 시 알림 전송
-  @PostMapping("/comment/{userId}/{reviewId}")
-  public ResponseEntity<Void> commentNotification(@PathVariable Long userId, @PathVariable Long reviewId) {
-    notificationService.commentAdded(userId, reviewId);
-    return ResponseEntity.ok().build();
-  }
-
-  // 인증 승인/거절 시 알림 전송
-  @PostMapping("certification/{userId}")
-  public ResponseEntity<Void> certificationNotification(@PathVariable Long userId) {
-    notificationService.certificateResult(userId);
-    return ResponseEntity.ok().build();
   }
 
 }

--- a/ddv/src/main/java/community/ddv/controller/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/controller/NotificationController.java
@@ -3,10 +3,9 @@ package community.ddv.controller;
 import community.ddv.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -18,12 +17,10 @@ public class NotificationController {
   private final NotificationService notificationService;
 
   // 클라이언트가 SSE 연결 구독
-  @GetMapping(value = "/subscribe/{userId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public ResponseEntity<SseEmitter> subscribe(@PathVariable Long userId) {
-    SseEmitter emitter = new SseEmitter(300_000L); // 타임아웃 5분
+  @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter subscribe(@RequestParam Long userId) {
 
-    notificationService.subscribe(userId, emitter);
-    return ResponseEntity.ok(emitter);
+    return notificationService.subscribe(userId);
   }
 
 }

--- a/ddv/src/main/java/community/ddv/dto/NotificationDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/NotificationDTO.java
@@ -1,0 +1,16 @@
+package community.ddv.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class NotificationDTO {
+
+  private String message;
+  private LocalDateTime createdAt;
+
+
+
+}

--- a/ddv/src/main/java/community/ddv/dto/NotificationDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/NotificationDTO.java
@@ -9,8 +9,6 @@ import lombok.Getter;
 public class NotificationDTO {
 
   private String message;
-  private LocalDateTime createdAt;
-
-
+  private Long relatedId;
 
 }

--- a/ddv/src/main/java/community/ddv/entity/Notification.java
+++ b/ddv/src/main/java/community/ddv/entity/Notification.java
@@ -1,0 +1,49 @@
+package community.ddv.entity;
+
+import community.ddv.constant.NotificationType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Notification {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  private NotificationType notificationType; // 알림 타입/메시지
+
+  public String getNotificationType() {
+    return notificationType.getMessage();
+  }
+
+  private boolean isRead; // 확인 여부
+
+  public void markAsRead() {
+    isRead = true;
+  }
+
+  private LocalDateTime createdAt;
+
+
+
+
+
+}

--- a/ddv/src/main/java/community/ddv/entity/Notification.java
+++ b/ddv/src/main/java/community/ddv/entity/Notification.java
@@ -42,8 +42,4 @@ public class Notification {
 
   private LocalDateTime createdAt;
 
-
-
-
-
 }

--- a/ddv/src/main/java/community/ddv/repository/NotificationRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package community.ddv.repository;
+
+import community.ddv.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/ddv/src/main/java/community/ddv/service/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/service/CertificationService.java
@@ -141,8 +141,8 @@ public class CertificationService {
     }
     log.info("인증 상태 변경 : {}", certification.getStatus());
     certificationRepository.save(certification);
-
     notificationService.certificateResult(certification.getUser().getId(), certification.getStatus());
+
   }
 
   // 사용자가 특정 영화에 대해 인증된 상태인지 확인

--- a/ddv/src/main/java/community/ddv/service/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/service/CertificationService.java
@@ -28,6 +28,7 @@ public class CertificationService {
   private final CertificationRepository certificationRepository;
   private final FileStorageService fileStorageService;
   private final UserService userService;
+  private final NotificationService notificationService;
 
   /**
    * 일반사용자 _ 영화를 봤는지 인증을 위한 인증샷 제출 (특정 영화의 리뷰에 참여하기 위함)
@@ -140,6 +141,8 @@ public class CertificationService {
     }
     log.info("인증 상태 변경 : {}", certification.getStatus());
     certificationRepository.save(certification);
+
+    notificationService.certificateResult(certification.getUser().getId(), certification.getStatus());
   }
 
   // 사용자가 특정 영화에 대해 인증된 상태인지 확인

--- a/ddv/src/main/java/community/ddv/service/CommentService.java
+++ b/ddv/src/main/java/community/ddv/service/CommentService.java
@@ -24,6 +24,7 @@ public class CommentService {
   private final UserService userService;
   private final CommentRepository commentRepository;
   private final ReviewRepository reviewRepository;
+  private final NotificationService notificationService;
 
   @Transactional
   public CommentResponseDto createComment(Long reviewId, CommentRequestDto commentRequestDto) {
@@ -65,6 +66,8 @@ public class CommentService {
 
     comment.updateContent(commentRequestDto.getContent());
     log.info("댓글 수정 완료");
+
+    notificationService.commentAdded(user.getId(), reviewId);
     return convertToCommentResponse(comment);
   }
 

--- a/ddv/src/main/java/community/ddv/service/CommentService.java
+++ b/ddv/src/main/java/community/ddv/service/CommentService.java
@@ -44,6 +44,7 @@ public class CommentService {
 
     Comment newComment = commentRepository.save(comment);
     log.info("댓글 작성 완료");
+    notificationService.commentAdded(user.getId(), reviewId);
     return convertToCommentResponse(newComment);
   }
 
@@ -67,7 +68,6 @@ public class CommentService {
     comment.updateContent(commentRequestDto.getContent());
     log.info("댓글 수정 완료");
 
-    notificationService.commentAdded(user.getId(), reviewId);
     return convertToCommentResponse(comment);
   }
 

--- a/ddv/src/main/java/community/ddv/service/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/service/NotificationService.java
@@ -1,0 +1,115 @@
+package community.ddv.service;
+
+import community.ddv.constant.CertificationStatus;
+import community.ddv.constant.ErrorCode;
+import community.ddv.constant.NotificationType;
+import community.ddv.dto.NotificationDTO;
+import community.ddv.entity.Notification;
+import community.ddv.entity.User;
+import community.ddv.exception.DeepdiviewException;
+import community.ddv.repository.NotificationRepository;
+import community.ddv.repository.UserRepository;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  // SSE 연결을 저장할 Map
+  private final Map<Long, SseEmitter> userEmitters = new ConcurrentHashMap<>();
+  private final UserService userService;
+  private final UserRepository userRepository;
+  private final NotificationRepository notificationRepository;
+
+  /**
+   * SSE 구독 메서드
+   * @param userId
+   * @param emitter
+   */
+  public void subscribe(Long userId, SseEmitter emitter) {
+
+    // 사용자에게 하나의 SSE 연결만 허용
+    if (userEmitters.containsKey(userId)) {
+      emitter.complete(); // 기존에 연결된 게 있으면 종료 처리
+    }
+
+    // 새 연결 저장
+    userEmitters.put(userId, emitter);
+
+    // 연결 종료시 emitter 제거
+    emitter.onCompletion(() -> userEmitters.remove(userId));
+    emitter.onTimeout(() -> userEmitters.remove(userId));
+  }
+
+  /**
+   * 알림 전송 메서드
+   * @param userId
+   * @param notificationDTO
+   */
+  public void sendNotification(Long userId, NotificationDTO notificationDTO) {
+    SseEmitter emitter = userEmitters.get(userId);
+
+    if (emitter != null) {
+      try {
+        emitter.send(notificationDTO);
+      } catch (IOException e) {
+        emitter.completeWithError(e);
+      }
+    }
+  }
+
+  /**
+   * 리뷰에 댓글이 달렸을 때의 알람
+   * @param userId
+   * @param reviewId
+   */
+  public void commentAdded(Long userId, Long reviewId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new DeepdiviewException(ErrorCode.USER_NOT_FOUND));
+
+    NotificationDTO notificationDTO = new NotificationDTO(
+        NotificationType.COMMENT_ADDED.getMessage(), reviewId
+    );
+
+    Notification notification = Notification.builder()
+        .user(user)
+        .notificationType(NotificationType.COMMENT_ADDED)
+        .isRead(false)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    notificationRepository.save(notification);
+
+    sendNotification(userId, notificationDTO);
+  }
+
+  public void certificateResult(Long userId, CertificationStatus status) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new DeepdiviewException(ErrorCode.USER_NOT_FOUND));
+
+    String message ="";
+    if (status == CertificationStatus.APPROVED) {
+      message = "인증이 승인되었습니다.";
+    } else if (status == CertificationStatus.REJECTED) {
+      message = "인증이 거절되었습니다.";
+    }
+
+    NotificationDTO notificationDTO = new NotificationDTO(message, userId);
+
+    Notification notification = Notification.builder()
+        .user(user)
+        .notificationType(NotificationType.CERTIFICATION_RESULT)
+        .isRead(false)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    notificationRepository.save(notification);
+    sendNotification(userId, notificationDTO);
+  }
+}

--- a/ddv/src/main/java/community/ddv/service/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/service/NotificationService.java
@@ -23,7 +23,6 @@ public class NotificationService {
 
   // SSE 연결을 저장할 Map
   private final Map<Long, SseEmitter> userEmitters = new ConcurrentHashMap<>();
-  private final UserService userService;
   private final UserRepository userRepository;
   private final NotificationRepository notificationRepository;
 
@@ -93,7 +92,7 @@ public class NotificationService {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.USER_NOT_FOUND));
 
-    String message ="";
+    String message = "";
     if (status == CertificationStatus.APPROVED) {
       message = "인증이 승인되었습니다.";
     } else if (status == CertificationStatus.REJECTED) {


### PR DESCRIPTION
# [변경사항]

1. 게시물에 댓글이 달릴시, 인증 상태가 변경될 시 알람이 자동으로 가도록 SSE를 활용하여 구현했습니다. 
2. GET http://~~~:8080/api/notifications/subscribe
  - 파라미터 : 
      - key: userId
      - value:~~
  - 헤더 : 
    - Authorization : Bearer ~~~
    - Accept : text/event-stream
3. 타임아웃을 3분으로 지정해두었기 때문에 3분마다 재연결을 해야 합니다. 이건 FE쪽에서 해야하는 것 같습니다. 