### PR TITLE
Feat : 알림 목록 조회, 알림 읽음처리 로직 구현

### DIFF
--- a/ddv/src/main/java/community/ddv/constant/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/constant/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode {
   IMAGE_FILE_ONLY("이미지 파일(jpg, jpeg, png, gif)만 업로드 가능합니다.", HttpStatus.BAD_REQUEST),
   VOTE_RESULT_NOT_FOUND("투표 결과가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
   NOT_CERTIFIED_YET("토론 작성 권한이 없습니다. 인증을 먼저 완료해주세요", HttpStatus.UNAUTHORIZED),
-  INVALID_REVIEW_PERIOD("토론 작성 기간이 아닙니다. 다음 주에 새로운 영화로 만나요", HttpStatus.BAD_REQUEST);
+  INVALID_REVIEW_PERIOD("토론 작성 기간이 아닙니다. 다음 주에 새로운 영화로 만나요", HttpStatus.BAD_REQUEST),
+  NOTIFICATION_NOT_FOUND("존재하지 않는 알람입니다.", HttpStatus.NOT_FOUND);
 
 
   private final String description;

--- a/ddv/src/main/java/community/ddv/controller/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/controller/NotificationController.java
@@ -1,9 +1,15 @@
 package community.ddv.controller;
 
+import community.ddv.dto.NotificationResponseDTO;
 import community.ddv.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,10 +23,26 @@ public class NotificationController {
   private final NotificationService notificationService;
 
   // 클라이언트가 SSE 연결 구독
+  @Operation(summary = "SSE 연결 구독")
   @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   public SseEmitter subscribe(@RequestParam Long userId) {
 
     return notificationService.subscribe(userId);
+  }
+
+  @Operation(summary = "알림 목록 조회")
+  @GetMapping
+  public ResponseEntity<List<NotificationResponseDTO>> getNotifications() {
+    List<NotificationResponseDTO> notifications = notificationService.getNotifications();
+    return ResponseEntity.ok(notifications);
+  }
+
+  @Operation(summary = "특정 알림 읽음처리")
+  @PostMapping("/{notificationId}/read")
+  public ResponseEntity<Void> markNotificationAsRead(
+      @PathVariable Long notificationId) {
+    notificationService.markNotificationAsRead(notificationId);
+    return ResponseEntity.ok().build();
   }
 
 }

--- a/ddv/src/main/java/community/ddv/dto/NotificationDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/NotificationDTO.java
@@ -9,6 +9,6 @@ import lombok.Getter;
 public class NotificationDTO {
 
   private String message;
-  private Long relatedId;
+  private Long relatedId; // 댓글이 달린 리뷰 ID , 인증 ID
 
 }

--- a/ddv/src/main/java/community/ddv/dto/NotificationResponseDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/NotificationResponseDTO.java
@@ -1,0 +1,19 @@
+package community.ddv.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NotificationResponseDTO {
+  private Long notificationId;
+  private String message;
+  private boolean isRead;
+  private LocalDateTime createdAt;
+
+}

--- a/ddv/src/main/java/community/ddv/entity/Notification.java
+++ b/ddv/src/main/java/community/ddv/entity/Notification.java
@@ -12,12 +12,14 @@ import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class Notification {
 
   @Id
@@ -29,10 +31,6 @@ public class Notification {
 
   @Enumerated(EnumType.STRING)
   private NotificationType notificationType; // 알림 타입/메시지
-
-  public String getNotificationType() {
-    return notificationType.getMessage();
-  }
 
   private boolean isRead; // 확인 여부
 

--- a/ddv/src/main/java/community/ddv/repository/NotificationRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/NotificationRepository.java
@@ -1,10 +1,15 @@
 package community.ddv.repository;
 
 import community.ddv.entity.Notification;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  Optional<Notification> findByIdAndUser_Id(Long notificationId, Long userId);
+  List<Notification> findByUser_IdOrderByCreatedAtDesc(Long userId);
 
 }

--- a/ddv/src/main/java/community/ddv/service/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/service/CertificationService.java
@@ -151,7 +151,7 @@ public class CertificationService {
     log.info("인증 상태 변경 : {}", certification.getStatus());
     certificationRepository.save(certification);
 
-    notificationService.certificateResult(certification.getUser().getId(), certification.getStatus());
+    notificationService.certificateResult(certification.getId(), certification.getStatus());
     log.info("인증 결과 알림 전송");
 
   }


### PR DESCRIPTION
# [변경사항]

1. 그동안 받은 알림 목록 리스트를 조회할 수 있도록 추가했습니다. 
2. 특정 알림을 읽음 표시 할 수 있는 기능을 추가했습니다. (읽으면 isRead == true로 바뀝니다)
3. 인증 상태 알림이 들어올 시, 알림 메시지와 함께 관련 Id로 (유저 ID -> 인증 ID)로 수정했습니다.  

# [특이사항]
- 일단 한 기기에서만 알림을 받는 것으로 구현했는데 확장을 해볼까 고민중입니다. 