### PR TITLE
Feat : 리뷰 조회시 로그인 사용자의 좋아요 여부 response 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 ## 사용 기술 스택
 - 언어 : Java (JDK 17)
 - 프레임워크 : SpringBoot 3.4
-- DB : MySQL, Redis
+- 데이터베이스 : MySQL, Redis
 - 파일 저장 : AWS S3
 - ORM : Spring Data JPA
 - 보안 : Spring Security, JWT (jjwt 0.12)
 - 실시간 통신 : SSE
-- 배포 환경 : AWS EC2 + NginX + Spring Boot, Github Actions (CI/CD)
+- 배포 환경 : AWS EC2 + NginX + Spring Boot, Github Actions(CI/CD)
 - 프로토콜 : Https 지원
 - API 문서화 : Swagger
 
@@ -38,12 +38,13 @@ https://github.com/user-attachments/assets/d3e371d5-d93e-41f9-94f6-cf885f38626e
 ### 1️⃣ 사용자
 - 권한 : 일반 사용자(USER), 관리자(ADMIN)
 - 인증 : JWT 기반 로그인 (Access Token + Refresh Token)
-- 회원가입 및 로그인 후, 인증된 사용자만 특정 기능 사용 가능 
+- 회원가입 및 로그인 후, 인증된 사용자만 특정 기능 사용가능
+  - 비로그인 : 영화 조회, 리뷰/댓글 조회만 가능  
 ### 2️⃣ TMDB API를 활용한 영화정보 제공
 -  매주 월요일 0시 넷플릭스(KR) 영화 데이터 자동 업데이트
    -  더 이상 제공되지 않는 영화는 DB에서 삭제되지 않고 상태만 변경됨 
 - 영화 제목 및 키워드 검색 지원
-  - 띄어쓰기 무시 가능  
+  - 띄어쓰기 무시 가능 (ex. 다크나이트 = 다크 나이트)
 ### 3️⃣ 영화 투표 (매주 진행)
 - 투표 대상 : 넷플릭스 인기 TOP 5 영화
 - 생성 (관리자 권한)
@@ -70,6 +71,7 @@ https://github.com/user-attachments/assets/d3e371d5-d93e-41f9-94f6-cf885f38626e
 ### 6️⃣ 좋아요
 - 특정 리뷰에 대해 한 번만 가능
   - 두 번 누를 시 취소
+- 좋아요 순 리뷰 정렬 기능 제공
 ### 7️⃣ 토론 (인증 리뷰)
 - 인증 승인을 받은 사용자만 작성할 수 있는 토론 게시판 제공 
 - 인증하기 전에 작성했던 리뷰가 있는 경우

--- a/ddv/src/main/java/community/ddv/dto/ReviewResponseDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/ReviewResponseDTO.java
@@ -1,5 +1,6 @@
 package community.ddv.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import community.ddv.dto.CommentDTO.CommentResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,6 +24,7 @@ public class ReviewResponseDTO {
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
   private Integer likeCount;
+  private Boolean likedByUser;
   private Long tmdbId;
   private String movieTitle;
   private String posterPath;

--- a/ddv/src/main/java/community/ddv/entity/Like.java
+++ b/ddv/src/main/java/community/ddv/entity/Like.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -21,6 +22,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 @Builder
 public class Like {
 

--- a/ddv/src/main/java/community/ddv/entity/Review.java
+++ b/ddv/src/main/java/community/ddv/entity/Review.java
@@ -66,6 +66,10 @@ public class Review {
   @Builder.Default
   private Integer likeCount = 0;
 
+  @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
+  @Builder.Default
+  private List<Like> likes = new ArrayList<>();
+
   private boolean certified;
 
   public void updateCertified(boolean certified) {

--- a/ddv/src/main/java/community/ddv/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/service/ReviewService.java
@@ -210,6 +210,12 @@ public class ReviewService {
 
 
   private ReviewResponseDTO convertToResponseDto(Review review) {
+
+    User loginUser = userService.getLoginOrNull();
+    Boolean likedByUser = (loginUser != null) ?
+        review.getLikes().stream().anyMatch(like -> like.getUser().equals(loginUser))
+        : null;
+
     Movie movie = review.getMovie();
     return ReviewResponseDTO.builder()
         .reviewId(review.getId())
@@ -221,6 +227,7 @@ public class ReviewService {
         .createdAt(review.getCreatedAt())
         .updatedAt(review.getUpdatedAt())
         .likeCount(review.getLikeCount())
+        .likedByUser(likedByUser)
         .tmdbId(movie.getTmdbId())
         .movieTitle(movie.getTitle())
         .posterPath(movie.getPosterPath())
@@ -229,6 +236,12 @@ public class ReviewService {
   }
 
   private ReviewResponseDTO convertToResponseWithCommentsDto(Review review) {
+
+    User loginUser = userService.getLoginOrNull();
+    Boolean likedByUser = (loginUser != null) ?
+        review.getLikes().stream().anyMatch(like -> like.getUser().equals(loginUser))
+        : null;
+
     Movie movie = review.getMovie();
     return ReviewResponseDTO.builder()
         .reviewId(review.getId())
@@ -240,6 +253,7 @@ public class ReviewService {
         .createdAt(review.getCreatedAt())
         .updatedAt(review.getUpdatedAt())
         .likeCount(review.getLikeCount())
+        .likedByUser(likedByUser)
         .tmdbId(movie.getTmdbId())
         .movieTitle(movie.getTitle())
         .posterPath(movie.getPosterPath())

--- a/ddv/src/main/java/community/ddv/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/service/UserService.java
@@ -359,6 +359,15 @@ public class UserService {
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.USER_NOT_FOUND));
   }
 
+  @Transactional(readOnly = true)
+  public User getLoginOrNull() {
+    try {
+      return getLoginUser();
+    } catch (DeepdiviewException e) {
+      return null;
+    }
+  }
+
   /**
    * 프로필 등록/수정
    * @param profileImage


### PR DESCRIPTION
# [변경사항]

1. 로그인 사용자 : 좋아요 여부가 T/F로 반환됩니다. 
    - 토큰을 사용해야 합니다.  (헤더에 Authorization: Bearer ~~~ 필요)
2.  미로그인 사용자: 좋아요 여부가 null로 반환됩니다. 
    - 토큰 불필요 