### PR TITLE
Fix : Cascade Delete 추가, 관리자 계정이 삭제되는 이슈 해결

### DIFF
--- a/ddv/src/main/java/community/ddv/constant/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/constant/ErrorCode.java
@@ -39,8 +39,8 @@ public enum ErrorCode {
   VOTE_RESULT_NOT_FOUND("투표 결과가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
   NOT_CERTIFIED_YET("토론 작성 권한이 없습니다. 인증을 먼저 완료해주세요", HttpStatus.UNAUTHORIZED),
   INVALID_REVIEW_PERIOD("토론 작성 기간이 아닙니다. 다음 주에 새로운 영화로 만나요", HttpStatus.BAD_REQUEST),
-  NOTIFICATION_NOT_FOUND("존재하지 않는 알람입니다.", HttpStatus.NOT_FOUND);
-
+  NOTIFICATION_NOT_FOUND("존재하지 않는 알람입니다.", HttpStatus.NOT_FOUND),
+  ADMIN_CANNOT_BE_DELETED("관리자 계정은 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST);
 
   private final String description;
   private final HttpStatus httpStatus;

--- a/ddv/src/main/java/community/ddv/entity/Review.java
+++ b/ddv/src/main/java/community/ddv/entity/Review.java
@@ -71,7 +71,7 @@ public class Review {
     likeCount = (likeCount == null || likeCount <= 0) ? 0 : likeCount - 1;
   }
 
-  @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   private List<Like> likes = new ArrayList<>();
 
@@ -82,7 +82,7 @@ public class Review {
   }
 
 
-  @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   private List<Comment> comments = new ArrayList<>();
 

--- a/ddv/src/main/java/community/ddv/entity/User.java
+++ b/ddv/src/main/java/community/ddv/entity/User.java
@@ -1,6 +1,7 @@
 package community.ddv.entity;
 
 import community.ddv.constant.Role;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
@@ -8,7 +9,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,4 +49,22 @@ public class User {
   private LocalDateTime createdAt;
   @LastModifiedDate
   private LocalDateTime updatedAt;
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Review> reviews = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Comment> comments = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Like> likes = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Certification> certifications = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<VoteParticipation> voteParticipations = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Notification> notifications = new ArrayList<>();
 }

--- a/ddv/src/main/java/community/ddv/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/service/UserService.java
@@ -179,6 +179,10 @@ public class UserService {
     User user = getLoginUser();
     log.info("회원탈퇴 요청 : {}", user.getEmail());
 
+    if (user.getRole() == Role.ADMIN) {
+      throw new DeepdiviewException(ErrorCode.ADMIN_CANNOT_BE_DELETED);
+    }
+
     // 비밀번호 확인
     if (!passwordEncoder.matches(accountDeleteDto.getPassword(), user.getPassword())) {
       throw new DeepdiviewException(ErrorCode.NOT_VALID_PASSWORD);


### PR DESCRIPTION
# [변경사항]

1. 데이터 삭제시 연관된 다른 데이터들도 함께 삭제 (Cascade Delete) 되도록 수정했습니다.
2. 관리자 계정이 탈퇴 시도할 시, 예외 메시지를 반환하며 삭제가 불가하도록 수정했습니다. 