### PR TITLE
Refactor : User 엔티티에서 Setter 애너테이션 삭제

### DIFF
--- a/ddv/src/main/java/community/ddv/entity/Certification.java
+++ b/ddv/src/main/java/community/ddv/entity/Certification.java
@@ -16,7 +16,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @NoArgsConstructor

--- a/ddv/src/main/java/community/ddv/entity/User.java
+++ b/ddv/src/main/java/community/ddv/entity/User.java
@@ -26,7 +26,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Setter
 @Builder
 @EntityListeners(AuditingEntityListener.class)
 public class User {
@@ -49,6 +48,7 @@ public class User {
   private LocalDateTime createdAt;
   @LastModifiedDate
   private LocalDateTime updatedAt;
+
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
@@ -73,4 +73,21 @@ public class User {
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   private List<Notification> notifications = new ArrayList<>();
+
+
+  public void updatePassword(String newPassword) {
+    this.password = newPassword;
+  }
+
+  public void updateNickname(String newNickname) {
+    this.nickname = newNickname;
+  }
+
+  public void updateProfileImageUrl(String newProfileImageUrl) {
+    this.profileImageUrl = newProfileImageUrl;
+  }
+
+  public void updateOneLineIntroduction(String newOneLineIntroduction) {
+    this.oneLineIntroduction = newOneLineIntroduction;
+  }
 }

--- a/ddv/src/main/java/community/ddv/entity/Vote.java
+++ b/ddv/src/main/java/community/ddv/entity/Vote.java
@@ -2,12 +2,9 @@ package community.ddv.entity;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/ddv/src/main/java/community/ddv/entity/VoteMovie.java
+++ b/ddv/src/main/java/community/ddv/entity/VoteMovie.java
@@ -19,7 +19,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Setter
 public class VoteMovie {
 
   @Id

--- a/ddv/src/main/java/community/ddv/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/service/UserService.java
@@ -221,7 +221,7 @@ public class UserService {
       }
 
       // 존재하지 않는 닉네임일 시, 닉네임 변경 성공
-      user.setNickname(newNickname);
+      user.updateNickname(newNickname);
       log.info("닉네임 변경성공");
     }
 
@@ -229,16 +229,14 @@ public class UserService {
       log.info("비밀번호 변경시도");
 
       if (!isValidPassword(newPassword)) {
-        log.info("8자 이상 입력하지 않았기 때문에 비밀번호 변경 실패");
         throw new DeepdiviewException(ErrorCode.NOT_ENOUGH_PASSWORD);
       } else {
         if (!newPassword.equals(newConfirmPassword)) {
-          log.info("비밀번호 확인 번호와 일치 하지 않기 떄문에 비밀번호 변경 실패");
           throw new DeepdiviewException(ErrorCode.NOT_VALID_PASSWORD);
         }
       }
 
-      user.setPassword(passwordEncoder.encode(newPassword));
+      user.updatePassword(passwordEncoder.encode(newPassword));
       log.info("비밀번호 변경성공");
     }
 
@@ -269,16 +267,16 @@ public class UserService {
     // 기존의 한줄소개가 없었던 경우
     if (user.getOneLineIntroduction() == null) {
       if (!newOneLineIntro.isEmpty()) {
-        user.setOneLineIntroduction(newOneLineIntro);
+        user.updateOneLineIntroduction(newOneLineIntro);
         log.info("한줄소개 설정 완료");
       }
     } else {
       // 기존의 한줄 소개가 존재하는 경우
       if (newOneLineIntro.isEmpty()) {
-        user.setOneLineIntroduction(null);
+        user.updateOneLineIntroduction(null);
         log.info("한줄소개 삭제 완료");
       } else {
-        user.setOneLineIntroduction(newOneLineIntro);
+        user.updateOneLineIntroduction(newOneLineIntro);
         log.info("한줄소개 수정 완료");
       }
     }
@@ -413,7 +411,7 @@ public class UserService {
       throw new IOException("새 프로필 사진 업로드 중 문제가 발생했습니다.");
     }
 
-    user.setProfileImageUrl(newProfileImageUrl);
+    user.updateProfileImageUrl(newProfileImageUrl);
     userRepository.save(user);
     log.info("프로필 이미지 등록/수정 완료");
     return newProfileImageUrl;
@@ -436,7 +434,7 @@ public class UserService {
         throw new IOException("프로필 사진 삭제 중 문제 발생");
       }
 
-      user.setProfileImageUrl(null);
+      user.updateProfileImageUrl(null);
       userRepository.save(user);
       log.info("프로필 사진 삭제 완료");
     }

--- a/ddv/src/main/java/community/ddv/service/VoteService.java
+++ b/ddv/src/main/java/community/ddv/service/VoteService.java
@@ -59,13 +59,13 @@ public class VoteService {
 
     // 투표 생성은 일요일만 가능, 한 주에 한 번만 가능
     LocalDateTime now = LocalDateTime.now();
-    if (now.getDayOfWeek() != DayOfWeek.SATURDAY) {
+    if (now.getDayOfWeek() != DayOfWeek.SUNDAY) {
       log.error("투표 생성은 일요일만 가능합니다 : 현재요일 = {}", now.getDayOfWeek());
       throw new DeepdiviewException(ErrorCode.INVALID_VOTE_CREAT_DATE);
     }
 
     // 이번주에 이미 생성된 투표가 있는지 확인
-    LocalDateTime weekStart = now.with(DayOfWeek.SATURDAY).with(LocalTime.MIN);
+    LocalDateTime weekStart = now.with(DayOfWeek.SUNDAY).with(LocalTime.MIN);
     LocalDateTime weekEnd = now.with(DayOfWeek.SATURDAY).with(LocalTime.MAX);
     boolean voteAlreadyExists = voteRepository.existsByStartDateBetween(weekStart, weekEnd);
     if (voteAlreadyExists) {


### PR DESCRIPTION
# [변경사항]

- 캡슐화 
  - Entity에서 Setter를 사용하면 필드 값이 외부에서 변경될 수 있기 때문에 변경 메서드를 따로 정의하는 것으로 변경
- 사용하지 않는 import문 정리  
