### PR TITLE
Feat : 관리자의 투표 삭제 기능 추가

### DIFF
--- a/ddv/src/main/java/community/ddv/controller/VoteController.java
+++ b/ddv/src/main/java/community/ddv/controller/VoteController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -53,5 +54,13 @@ public class VoteController {
       @PathVariable Long voteId) {
     VoteResultDTO voteResultDTO = voteService.getVoteResult(voteId);
     return ResponseEntity.ok(voteResultDTO);
+  }
+
+  @Operation(summary = "투표 삭제", description = "관리자만 삭제 가능")
+  @DeleteMapping("/{voteId}")
+  public ResponseEntity<Void> deleteVote(
+      @PathVariable Long voteId) {
+    voteService.deleteVote(voteId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/ddv/src/main/java/community/ddv/entity/Vote.java
+++ b/ddv/src/main/java/community/ddv/entity/Vote.java
@@ -31,6 +31,10 @@ public class Vote {
   @Builder.Default
   private List<VoteMovie> voteMovies = new ArrayList<>();
 
+  @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<VoteParticipation> voteParticipations = new ArrayList<>();
+
   private LocalDateTime startDate; // 투표 시작 날짜
   private LocalDateTime endDate; // 투표 마감 날짜
 

--- a/ddv/src/main/java/community/ddv/entity/VoteMovie.java
+++ b/ddv/src/main/java/community/ddv/entity/VoteMovie.java
@@ -12,7 +12,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Builder

--- a/ddv/src/main/java/community/ddv/service/VoteService.java
+++ b/ddv/src/main/java/community/ddv/service/VoteService.java
@@ -277,5 +277,28 @@ public class VoteService {
 
     return tmdbId;
   }
+
+  /**
+   * 관리자의 투표 삭제 기능
+   * @param voteId
+   */
+  @Transactional
+  public void deleteVote(Long voteId) {
+
+    User user = userService.getLoginUser();
+
+    if (!user.getRole().equals(Role.ADMIN)) {
+      log.error("관리자만 투표 삭제 가능");
+      throw new DeepdiviewException(ErrorCode.ONLY_ADMIN_CAN);
+    }
+
+    log.info("투표 삭제 시도");
+    Vote vote = voteRepository.findById(voteId)
+        .orElseThrow(() -> new DeepdiviewException(ErrorCode.VOTE_NOT_FOUND));
+
+    voteRepository.delete(vote);
+    log.info("투표 삭제 완료 voteId = {}", voteId);
+
+  }
 }
 

--- a/ddv/src/main/java/community/ddv/service/VoteService.java
+++ b/ddv/src/main/java/community/ddv/service/VoteService.java
@@ -59,13 +59,13 @@ public class VoteService {
 
     // 투표 생성은 일요일만 가능, 한 주에 한 번만 가능
     LocalDateTime now = LocalDateTime.now();
-    if (now.getDayOfWeek() != DayOfWeek.SUNDAY) {
+    if (now.getDayOfWeek() != DayOfWeek.MONDAY) {
       log.error("투표 생성은 일요일만 가능합니다 : 현재요일 = {}", now.getDayOfWeek());
       throw new DeepdiviewException(ErrorCode.INVALID_VOTE_CREAT_DATE);
     }
 
     // 이번주에 이미 생성된 투표가 있는지 확인
-    LocalDateTime weekStart = now.with(DayOfWeek.SUNDAY).with(LocalTime.MIN);
+    LocalDateTime weekStart = now.with(DayOfWeek.MONDAY).with(LocalTime.MIN);
     LocalDateTime weekEnd = now.with(DayOfWeek.SATURDAY).with(LocalTime.MAX);
     boolean voteAlreadyExists = voteRepository.existsByStartDateBetween(weekStart, weekEnd);
     if (voteAlreadyExists) {


### PR DESCRIPTION
# [변경사항]

두 개의 로직이 겹쳐있기 때문에 
  - 한 주에는 1개의 투표만 존재할 수 있다는 로직
  - 투표시작시간 (현재는 테스트용으로 1시간 전)부터 현재까지 존재하는  투표가 있는지 확인 후, 투표 결과를 반환
  
테스트 하기가 어려울 것으로 생각되어 오류 없이 테스트 할 수 있도록 투표 삭제 기능을 추가했습니다. 

----

- 관리자만 투표 삭제가 가능합니다. 

- 1시간 내에 여러 투표를 만들고 싶을 시 사용하시면 됩니다. 
- 투표를 새로 만들고 기존의 투표를 삭제를 하든, 삭제를 하고 새로 만들든 순서는 상관 없습니다. 