### PR TITLE
Fix : 인증 상태 초기화 오류 해결, 인증상태 조회시 null값이 안 나오도록 수정 

### DIFF
--- a/ddv/src/main/java/community/ddv/repository/CertificationRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/CertificationRepository.java
@@ -1,5 +1,6 @@
 package community.ddv.repository;
 
+import aj.org.objectweb.asm.commons.Remapper;
 import community.ddv.constant.CertificationStatus;
 import community.ddv.entity.Certification;
 import java.util.Optional;
@@ -26,4 +27,6 @@ public interface CertificationRepository extends JpaRepository<Certification, Lo
   int resetAllCertifications();
 
   Optional<Certification> findByUser_Id(Long userId);
+
+  Page<Certification> findByStatusIsNotNull(Pageable pageable);
 }

--- a/ddv/src/main/java/community/ddv/repository/CertificationRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/CertificationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface CertificationRepository extends JpaRepository<Certification, Long> {
@@ -21,7 +22,7 @@ public interface CertificationRepository extends JpaRepository<Certification, Lo
 
   // ENUM 타입을 NULL로 초기화 하기 위해 네이티브쿼리 사용
   @Modifying
-  @Query(value = "UPDATE Certification SET status = NULL, rejection_reason = NULL", nativeQuery = true)
+  @Query(value = "UPDATE certification SET status = NULL, rejection_reason = NULL", nativeQuery = true)
   int resetAllCertifications();
 
   Optional<Certification> findByUser_Id(Long userId);

--- a/ddv/src/main/java/community/ddv/service/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/service/CertificationService.java
@@ -79,7 +79,8 @@ public class CertificationService {
     if (status == null) {
       // 전체 조회
       log.info("인증 전체 조회");
-      return certificationRepository.findAll(pageable)
+      //return certificationRepository.findAll(pageable)
+      return certificationRepository.findByStatusIsNotNull(pageable)
           .map(this::convertToCertificationDto);
     } else {
       // 인증 상태에 따른 조회
@@ -159,7 +160,9 @@ public class CertificationService {
 
   // 인증상태 초기화 (새로운 주가 시작될 때 인증 상태를 null로 초기화)
   @Transactional
-  @Scheduled(cron = "0 0 0 * * MON")
+  //@Scheduled(cron = "0 0 0 * * MON")
+  // 테스트를 위해 매일 0시 정각에 초기화
+  @Scheduled(cron = "0 0 0 * * *")
   protected void resetCertificationStatus() {
 
     log.info("새로운 주가 됨에 따라 인증상태 초기화");


### PR DESCRIPTION
# [변경사항]

1. 테이블명을 대문자로 쓴 것 때문에 쿼리문 실행이 안 되는 문제 해결
2. 관리자가 인증 상태 조회시 NULL로 초기화 된 것은 조회되지 않도록 수정
3. 테스트를 위해 매일 0시마다 초기화하는 것으로 변경