### PR TITLE
Feat : 인기 20위 영화를 Redis에 캐시처리하여 성능 최적화

### DIFF
--- a/ddv/build.gradle
+++ b/ddv/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.3'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/ddv/src/main/java/community/ddv/component/Scheduler.java
+++ b/ddv/src/main/java/community/ddv/component/Scheduler.java
@@ -3,6 +3,9 @@ package community.ddv.component;
 import community.ddv.service.MovieApiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -12,13 +15,33 @@ import org.springframework.stereotype.Component;
 public class Scheduler {
 
   private final MovieApiService movieApiService;
+  private final CacheManager cacheManager;
 
-  // 매주 월요일 0시 0분 15초에 영화 데이터 업데이트
+  // 매주 월요일 0시 0분 15초에 영화 데이터 업데이트하면서 인기 영화 목록 캐시 초기화
   @Scheduled(cron = "15 0 0 * * MON")
   public void updateMovieApi() {
     log.info("영화정보 업데이트를 시작합니다.");
     movieApiService.fetchAndSaveMovies();
     log.info("영화정보 업데이트를 완료했습니다.");
+
+    clearTopMoviesCache();
   }
 
+  private void clearTopMoviesCache() {
+    Cache top20Cache = cacheManager.getCache("top20Movies");
+
+    if (top20Cache != null) {
+      top20Cache.clear();
+    }
+    log.info("인기영화 캐시 초기화 완료");
+  }
+
+//
+//  @Scheduled(cron = "0 0 0 * * *")
+//  @CacheEvict(value = "topRankMovie", key = "'last_week_top_movie'")
+//  public void evictTopRankMovie() {
+//    log.info("투표결과 캐시 무효화 완료");
+//  }
+
 }
+

--- a/ddv/src/main/java/community/ddv/config/RedisConfig.java
+++ b/ddv/src/main/java/community/ddv/config/RedisConfig.java
@@ -1,12 +1,20 @@
 package community.ddv.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -32,6 +40,29 @@ public class RedisConfig {
     template.setKeySerializer(new StringRedisSerializer());
     template.setValueSerializer(new StringRedisSerializer());
     return template;
+  }
+
+  @Bean
+  public CacheManager rediscacheManager(RedisConnectionFactory factory) {
+
+    // ObjectMapper 설정
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+
+    // GenericJackson2JsonRedisSerializer 사용하여 값 직렬화
+    GenericJackson2JsonRedisSerializer jackson2JsonRedisSerializer =
+        new GenericJackson2JsonRedisSerializer(objectMapper);
+
+    // RedisCacheConfiguration 설정
+    RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+        .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+        .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jackson2JsonRedisSerializer));
+        // TTL 설정할 거면 여기에 추가하기
+
+    // RedisCacheManager 설정
+    return RedisCacheManager.builder(factory)
+        .cacheDefaults(configuration)
+        .build();
   }
 
 }

--- a/ddv/src/main/java/community/ddv/dto/VoteDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/VoteDTO.java
@@ -20,7 +20,6 @@ public class VoteDTO {
     private String title; // 투표 제목
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    //private List<Long> movieTmdbIds; // 투표에 포함된 영화 리스트
     private List<VoteMovieResultDTO> movieDetails = new ArrayList<>();  // tmdbIds, 등수, 투표수
 
     public VoteCreatedDTO(Vote vote) {
@@ -30,12 +29,6 @@ public class VoteDTO {
       endDate = vote.getEndDate();
 
       int rank = 1;
-//      for (Movie movie : vote.getVoteMovies().stream().map(VoteMovie::getMovie).toList()) {
-//        VoteMovieResultDTO movieVoteDto = new VoteMovieResultDTO(
-//            movie.getTmdbId(),
-//            0,
-//            rank
-//        );
       for (VoteMovie voteMovie : vote.getVoteMovies()) {
         Movie movie = voteMovie.getMovie();
         VoteMovieResultDTO voteMovieResultDTO = new VoteMovieResultDTO(
@@ -49,9 +42,6 @@ public class VoteDTO {
 
       }
     }
-//      movieTmdbIds = vote.getMovies().stream()
-//          .map(Movie::getTmdbId)
-//          .collect(Collectors.toList());
   }
 
   @Getter

--- a/ddv/src/main/java/community/ddv/dto/VoteMovieResultDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/VoteMovieResultDTO.java
@@ -17,11 +17,4 @@ public class VoteMovieResultDTO {
   private int rank;      // 등수
   private LocalDateTime lastVotedTime; // 마지막 득표 시간
 
-  public VoteMovieResultDTO(Long tmdbId, int voteCount) {
-    this.tmdbId = tmdbId;
-    this.voteCount = voteCount;
-  }
-
-
-
 }

--- a/ddv/src/main/java/community/ddv/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/service/MovieService.java
@@ -15,12 +15,14 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -48,6 +50,8 @@ public class MovieService {
   /**
    * 넷플릭스 내 인기도 탑 20 영화 세부정보 조회
    */
+  @Transactional(readOnly = true)
+  @Cacheable(value = "top20Movies", key = "'top20Movies'")
   public List<MovieDTO> getTop20Movies() {
     return getTopMovies(20);
   }
@@ -55,6 +59,7 @@ public class MovieService {
   /**
    * 넷플릭스 내 인기도 탑 5 영화 세부정보 조회
    */
+  @Transactional(readOnly = true)
   public List<MovieDTO> getTop5Movies() {
     return getTopMovies(5);
   }

--- a/ddv/src/main/java/community/ddv/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/service/ReviewService.java
@@ -146,7 +146,6 @@ public class ReviewService {
       log.info("인증된 리뷰만 조회");
       reviews = reviewRepository.findByMovieAndCertifiedTrue(movie, pageable);
     } else {
-      log.info("모든 리뷰 조회");
       reviews = reviewRepository.findByMovie(movie, pageable);
     }
 

--- a/ddv/src/main/java/community/ddv/service/VoteService.java
+++ b/ddv/src/main/java/community/ddv/service/VoteService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -239,6 +240,7 @@ public class VoteService {
    * 지난 주 1위 영화 가져오는 메서드
    */
   @Transactional(readOnly = true)
+  // @Cacheable(value = "topRankMovie", key = "'last_week_top_movie'")
   public Long getLastWeekTopVoteMovie() {
     log.info("지난주 투표 1위 영화조회 시작");
     LocalDateTime now = LocalDateTime.now();
@@ -290,6 +292,9 @@ public class VoteService {
 
   }
 
+  /**
+   * 현재 진행중인 투표에 참여했는지 여부
+   */
   @Transactional(readOnly = true)
   public boolean isUserAlreadyParticipatedInCurrentVote() {
 


### PR DESCRIPTION
# [변경사항]

- 인덱스 페이지에서 인기 20위 영화를 계속 호출해야 하기 때문에 Redis에 캐시처리 하는 것이 낫겠다고 판단하였습니다. 
영화정보가 스케줄링 되면서 업데이트 될 때 캐시 초기화됩니다. 
  
- 이번주의 영화(지난주 투표 1위 영화) 조회의 경우도 마찬가지로 Redis 에 캐시처리 하려하였으나,  
현재 투표 API 연동 테스트로 인해 건들기가 어려워 일단은 해당 부분을 주석처리해두었습니다.