### PR TITLE
Fix : 파라미터에 id를 적지 않고도 진행 중인 투표 결과를 볼 수 있도록 수정, 반환형 키 값 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/config/SecurityConfig.java
@@ -41,8 +41,7 @@ public class SecurityConfig {
       "/api/movies/**",
       "/api/discussions/is-sunday",
       "/api/discussions/this-week-movie",
-      "/api/votes/result",
-      "/api/votes/result/latest"
+      "/api/votes/result"
   };
 
   @Bean

--- a/ddv/src/main/java/community/ddv/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
       "/api/movies/**",
       "/api/discussions/is-sunday",
       "/api/discussions/this-week-movie",
-      "/api/votes/{voteId}/result"
+      "/api/votes/result",
+      "/api/votes/result/latest"
   };
 
   @Bean

--- a/ddv/src/main/java/community/ddv/controller/DiscussionController.java
+++ b/ddv/src/main/java/community/ddv/controller/DiscussionController.java
@@ -58,7 +58,7 @@ public class DiscussionController {
   public ResponseEntity<Map<String, Long>> getThisWeekMovie() {
     Long tmdbId = voteService.getLastWeekTopVoteMovie();
     Map<String, Long> response = new HashMap<>();
-    response.put("이번주 영화 TmdbId", tmdbId);
+    response.put("TmdbId", tmdbId);
     return ResponseEntity.ok(response);
   }
 }

--- a/ddv/src/main/java/community/ddv/controller/VoteController.java
+++ b/ddv/src/main/java/community/ddv/controller/VoteController.java
@@ -47,11 +47,17 @@ public class VoteController {
     return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
   }
 
-  @Operation(summary = "투표 결과 확인")
-  @GetMapping("/{voteId}/result")
-  public ResponseEntity<VoteResultDTO> getVoteResult(
-      @PathVariable Long voteId) {
-    VoteResultDTO voteResultDTO = voteService.getVoteResult(voteId);
+  @Operation(summary = "현재 진행중인 투표 결과 확인", description = "현재 투표가 진행중일 때만 결과 확인 가능합니다.")
+  @GetMapping("/result")
+  public ResponseEntity<VoteResultDTO> getVoteResult() {
+    VoteResultDTO voteResultDTO = voteService.getCurrentVoteResult();
+    return ResponseEntity.ok(voteResultDTO);
+  }
+
+  @Operation(summary = "가장 최근 진행됐던 투표 결과 조회", description = "투표가 진행중일 때도, 끝났을 때도 결과 조회가 가능합니다.")
+  @GetMapping("/result/latest")
+  public ResponseEntity<VoteResultDTO> getLatestVoteResult() {
+    VoteResultDTO voteResultDTO = voteService.getLatestVoteResult();
     return ResponseEntity.ok(voteResultDTO);
   }
 

--- a/ddv/src/main/java/community/ddv/controller/VoteController.java
+++ b/ddv/src/main/java/community/ddv/controller/VoteController.java
@@ -32,7 +32,7 @@ public class VoteController {
     return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
   }
 
-  @Operation(summary = "현재 진행중인 투표의 선택지 조회")
+  @Operation(summary = "현재 진행중인 투표의 선택지 조회", description = "현재 투표가 진행중일 때만 조회 가능합니다.")
   @GetMapping("/options")
   public ResponseEntity<VoteOptionsDto> getActivatingVote() {
     VoteOptionsDto options = voteService.getVoteChoices();
@@ -51,13 +51,6 @@ public class VoteController {
   @GetMapping("/result")
   public ResponseEntity<VoteResultDTO> getVoteResult() {
     VoteResultDTO voteResultDTO = voteService.getCurrentVoteResult();
-    return ResponseEntity.ok(voteResultDTO);
-  }
-
-  @Operation(summary = "가장 최근 진행됐던 투표 결과 조회", description = "투표가 진행중일 때도, 끝났을 때도 결과 조회가 가능합니다.")
-  @GetMapping("/result/latest")
-  public ResponseEntity<VoteResultDTO> getLatestVoteResult() {
-    VoteResultDTO voteResultDTO = voteService.getLatestVoteResult();
     return ResponseEntity.ok(voteResultDTO);
   }
 

--- a/ddv/src/main/java/community/ddv/repository/VoteRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/VoteRepository.java
@@ -17,4 +17,6 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
 
   // 지난주 생성된 투표 조회
   Optional<Vote> findByStartDateBetween(LocalDateTime startDate, LocalDateTime endDate);
+
+  Optional<Vote> findTopByOrderByStartDateDesc();
 }

--- a/ddv/src/main/java/community/ddv/service/VoteService.java
+++ b/ddv/src/main/java/community/ddv/service/VoteService.java
@@ -59,13 +59,13 @@ public class VoteService {
 
     // 투표 생성은 일요일만 가능, 한 주에 한 번만 가능
     LocalDateTime now = LocalDateTime.now();
-    if (now.getDayOfWeek() != DayOfWeek.WEDNESDAY) {
+    if (now.getDayOfWeek() != DayOfWeek.THURSDAY) {
       log.error("투표 생성은 일요일만 가능합니다 : 현재요일 = {}", now.getDayOfWeek());
       throw new DeepdiviewException(ErrorCode.INVALID_VOTE_CREAT_DATE);
     }
 
     // 이번주에 이미 생성된 투표가 있는지 확인
-    LocalDateTime weekStart = now.with(DayOfWeek.WEDNESDAY).with(LocalTime.MIN);
+    LocalDateTime weekStart = now.with(DayOfWeek.THURSDAY).with(LocalTime.MIN);
     LocalDateTime weekEnd = now.with(DayOfWeek.SATURDAY).with(LocalTime.MAX);
     boolean voteAlreadyExists = voteRepository.existsByStartDateBetween(weekStart, weekEnd);
     if (voteAlreadyExists) {
@@ -262,16 +262,16 @@ public class VoteService {
   }
 
 
-  /**
-   * 가장 최근 진행됐던 투표 결과 조회
-   */
-  @Transactional(readOnly = true)
-  public VoteResultDTO getLatestVoteResult() {
-    Vote latestVote = voteRepository.findTopByOrderByStartDateDesc()
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.VOTE_NOT_FOUND));
-    log.info("가장 최근에 진행했던 투표 결과 조회");
-    return getVoteResult(latestVote.getId());
-  }
+//  /**
+//   * 가장 최근 진행됐던 투표 결과 조회
+//   */
+//  @Transactional(readOnly = true)
+//  public VoteResultDTO getLatestVoteResult() {
+//    Vote latestVote = voteRepository.findTopByOrderByStartDateDesc()
+//        .orElseThrow(() -> new DeepdiviewException(ErrorCode.VOTE_NOT_FOUND));
+//    log.info("가장 최근에 진행했던 투표 결과 조회");
+//    return getVoteResult(latestVote.getId());
+//  }
 
   /**
    * 지난 주 1위 영화 가져오는 메서드


### PR DESCRIPTION
# [변경사항]

1. 이 주의 영화 조회 시, 반환형의 키 값을 영어로 변경 

2. /api/votes/{voteId}/result -> /api/votes/result 로 파라미터 없이 결과 조회 되도록 수정  

3. 투표 계산 메서드, 투표 결과 추출 메서드 분리
