### PR TITLE
Refactor : 투표의 본래 일정에 맞춰 수정 & Feat : 지난주의 투표 전체 결과 조회 기능 추가 

### DIFF
--- a/ddv/src/main/java/community/ddv/controller/VoteController.java
+++ b/ddv/src/main/java/community/ddv/controller/VoteController.java
@@ -68,4 +68,11 @@ public class VoteController {
     boolean participated = voteService.isUserAlreadyParticipatedInCurrentVote();
     return ResponseEntity.ok(participated);
   }
+
+  @Operation(summary = "지난주 투표 전체 결과 조회", description = "지난주에 진행한 투표의 전체 결과를 볼 수 있습니다.")
+  @GetMapping("/result/latest")
+  public ResponseEntity<VoteResultDTO> getLatestVoteResult() {
+    VoteResultDTO voteResultDTO = voteService.getLatestVoteResult();
+    return ResponseEntity.ok(voteResultDTO);
+  }
 }

--- a/ddv/src/main/java/community/ddv/repository/VoteRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/VoteRepository.java
@@ -2,6 +2,7 @@ package community.ddv.repository;
 
 import community.ddv.entity.Vote;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -18,5 +19,5 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
   // 지난주 생성된 투표 조회
   Optional<Vote> findByStartDateBetween(LocalDateTime startDate, LocalDateTime endDate);
 
-  Optional<Vote> findTopByOrderByStartDateDesc();
+  List<Vote> findTop2ByOrderByStartDateDesc();
 }


### PR DESCRIPTION
# [변경사항]

-  원래 기획했던 투표 일정에 맞게 수정했습니다. 
   - 일요일에만 생성 가능, 중복 생성 불가 
   - 투표 기간 : 월 - 토

- 지난주에 진행했던 투표의 전체 결과를 조회할 수 있도록 추가했습니다.  
