### PR TITLE
Feat : 인증샷과 상태 조회 API, 수정 API, 삭제 API 구현

### DIFF
--- a/ddv/src/main/java/community/ddv/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
       "/api/movies/**",
       "/api/discussions/is-sunday",
       "/api/discussions/this-week-movie",
-      "/api/votes/result"
+      "/api/votes/result",
+      "/api/votes/result/latest"
   };
 
   @Bean

--- a/ddv/src/main/java/community/ddv/controller/CertificationController.java
+++ b/ddv/src/main/java/community/ddv/controller/CertificationController.java
@@ -5,6 +5,7 @@ import community.ddv.dto.CertificationDTO.CertificationRequestDto;
 import community.ddv.dto.CertificationDTO.CertificationResponseDto;
 import community.ddv.service.CertificationService;
 import io.swagger.v3.oas.annotations.Operation;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,9 +13,11 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,6 +36,27 @@ public class CertificationController {
   public ResponseEntity<CertificationResponseDto> submitCertification(
       @RequestParam("file") MultipartFile file) throws Exception {
     return ResponseEntity.ok(certificationService.submitCertification(file));
+  }
+
+  @Operation(summary = "인증샷, 상태 확인", description = "인증샷 url, 인증상태 반환")
+  @GetMapping("/me")
+  public ResponseEntity<CertificationResponseDto> getCertification() {
+    CertificationResponseDto certificationResponseDto = certificationService.getMyCertification();
+    return ResponseEntity.ok(certificationResponseDto);
+  }
+
+  @Operation(summary = "인증샷 수정", description = "파일 재업로드, PENDING/REJECTED 상태의 유저만 사용 가능")
+  @PutMapping
+  public ResponseEntity<CertificationResponseDto> updateCertification(
+      @RequestParam("file") MultipartFile file) throws Exception {
+    return ResponseEntity.ok(certificationService.updateCertification(file));
+  }
+
+  @Operation(summary = "인증샷 삭제", description = "PENDING/REJECTED 상태의 유저만 사용 가능")
+  @DeleteMapping
+  public ResponseEntity<Void> deleteCertification() throws IOException {
+    certificationService.deleteCertification();
+    return ResponseEntity.noContent().build();
   }
 
   @Operation(summary = "인증 목록 조회", description = "관리자 전용 - 보류, 승인, 거절 필터링 가능 | 한 페이지당 10개씩 반환 ㅣ 인증요청을 한 지 오래된 순서대로 정렬됩니다.")

--- a/ddv/src/main/java/community/ddv/controller/CertificationController.java
+++ b/ddv/src/main/java/community/ddv/controller/CertificationController.java
@@ -45,13 +45,6 @@ public class CertificationController {
     return ResponseEntity.status(HttpStatus.OK).body(certifications);
   }
 
-  @Operation(summary = "특정 인증정보 조회_인증샷 확인", description = "관리자 전용")
-  @GetMapping("/admin/{certificationId}")
-  public ResponseEntity<CertificationResponseDto> getCertificationById(
-      @PathVariable Long certificationId) {
-    CertificationResponseDto certification = certificationService.getCertification(certificationId);
-    return ResponseEntity.status(HttpStatus.OK).body(certification);
-  }
 
   @Operation(summary = "인증 승인/거절", description = "관리자 전용 - 승인 : true / 거절 : false | 거절시 rejectionReason: OTHER_MOVIE_IMAGE, WRONG_IMAGE, UNIDENTIFIABLE_IMAGE")
   @PostMapping("/admin/proceeding/{certificationId}")

--- a/ddv/src/main/java/community/ddv/controller/DiscussionController.java
+++ b/ddv/src/main/java/community/ddv/controller/DiscussionController.java
@@ -37,16 +37,6 @@ public class DiscussionController {
     return ResponseEntity.status(HttpStatus.CREATED).body(review);
   }
 
-  @Operation(summary = "인증승인된 사용자의 댓글 작성")
-  @PostMapping("/comments/{reviewId}")
-  public ResponseEntity<CommentResponseDto> createDiscussionComment(
-      @PathVariable Long reviewId,
-      @RequestBody @Valid CommentRequestDto commentRequestDto) {
-
-    CommentResponseDto comment = discussionService.createDiscussionComment(reviewId, commentRequestDto);
-    return ResponseEntity.status(HttpStatus.CREATED).body(comment);
-  }
-
   @Operation(summary = "일요일인지 여부 T/F")
   @GetMapping("/is-sunday")
   public ResponseEntity<Boolean> isSunday() {

--- a/ddv/src/main/java/community/ddv/controller/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/controller/NotificationController.java
@@ -8,8 +8,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,10 +40,17 @@ public class NotificationController {
   }
 
   @Operation(summary = "특정 알림 읽음처리")
-  @PostMapping("/{notificationId}/read")
+  @PutMapping("/{notificationId}/read")
   public ResponseEntity<Void> markNotificationAsRead(
       @PathVariable Long notificationId) {
     notificationService.markNotificationAsRead(notificationId);
+    return ResponseEntity.ok().build();
+  }
+
+  @Operation(summary = "전체 알림 읽음처리")
+  @PutMapping("/read-all")
+  public ResponseEntity<Void> markAllNotificationAsRead() {
+    notificationService.markAllNotificationAsRead();
     return ResponseEntity.ok().build();
   }
 

--- a/ddv/src/main/java/community/ddv/dto/NotificationDTO.java
+++ b/ddv/src/main/java/community/ddv/dto/NotificationDTO.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public class NotificationDTO {
 
+  private Long notificationId;
   private String type;
   private String message;
   private Long relatedId; // 댓글이 달린 리뷰 ID , 인증 ID

--- a/ddv/src/main/java/community/ddv/entity/Certification.java
+++ b/ddv/src/main/java/community/ddv/entity/Certification.java
@@ -16,12 +16,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
+@Setter
 public class Certification {
 
   @Id

--- a/ddv/src/main/java/community/ddv/repository/NotificationRepository.java
+++ b/ddv/src/main/java/community/ddv/repository/NotificationRepository.java
@@ -11,5 +11,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
   Optional<Notification> findByIdAndUser_Id(Long notificationId, Long userId);
   List<Notification> findByUser_IdOrderByCreatedAtDesc(Long userId);
+  List<Notification> findByUser_IdAndIsReadFalseOrderByCreatedAtDesc(Long userId);
 
 }

--- a/ddv/src/main/java/community/ddv/service/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/service/CertificationService.java
@@ -91,24 +91,6 @@ public class CertificationService {
 
   }
 
-  /**
-   * 관리자 _ 특정 인증 정보 가져오는 메서드 (이미지 확인용)
-   * @param certificationId
-   * @return
-   */
-  public CertificationResponseDto getCertification(Long certificationId) {
-
-    log.info("특정 인증 정보 조회 시작(인증 이미지 확인) : certificationId = {}", certificationId);
-    userService.getLoginUser();
-    Certification certification = certificationRepository.findById(certificationId)
-        .orElseThrow(() -> {
-          log.error("인증 정보를 찾을 수 없음");
-          return new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND);
-        });
-
-    log.info("특정 인증 정보 조회 성공(인증 이미지 확인 완료)");
-    return convertToCertificationDto(certification);
-  }
 
   /**
    * 관리자 _ 인증 처리 (승인 : true, 거절 : false) & 거절 메시지

--- a/ddv/src/main/java/community/ddv/service/DiscussionService.java
+++ b/ddv/src/main/java/community/ddv/service/DiscussionService.java
@@ -83,26 +83,6 @@ public class DiscussionService {
     return reviewService.createReview(reviewDTO);
   }
 
-  /**
-   * 인증 승인된 사용자의 댓글 작성
-   * @param reviewId
-   * @param commentRequestDto
-   */
-  @Transactional
-  public CommentResponseDto createDiscussionComment(Long reviewId, CommentRequestDto commentRequestDto) {
-
-    User user = userService.getLoginUser();
-    if (!certificationService.isUserCertified(user.getId())) {
-      log.warn("인증되지 않은 사용자 : userId = {}", user.getId());
-      throw new DeepdiviewException(ErrorCode.NOT_CERTIFIED_YET);
-    }
-    log.info("인증 상태 확인 완료 : userId = {}", user.getId());
-
-    Review review = reviewRepository.findById(reviewId)
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
-
-    return commentService.createComment(review.getId(), commentRequestDto);
-  }
 
   // 일요일 확인 API
   public boolean isTodaySunday() {

--- a/ddv/src/main/java/community/ddv/service/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/service/NotificationService.java
@@ -271,7 +271,10 @@ public class NotificationService {
         .build();
   }
 
-  // 알림 읽음 처리
+   /**
+   * 특정 알림 읽음 처리
+   * @param notificationId
+   */
   public void markNotificationAsRead(Long notificationId) {
     User user = userService.getLoginUser();
     log.info("알림 읽음 시도 : userId = {}", user.getId());
@@ -284,4 +287,10 @@ public class NotificationService {
       log.info("알림 읽음처리 완료");
     }
   }
+
+  /**
+   * 전체 알림 읽음 처리
+   */
+
+
 }

--- a/ddv/src/main/java/community/ddv/service/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/service/NotificationService.java
@@ -160,10 +160,6 @@ public class NotificationService {
       return;
     }
 
-    NotificationDTO notificationDTO = new NotificationDTO(
-        "comment", NotificationType.COMMENT_ADDED.getMessage(), reviewId
-    );
-
     Notification notification = Notification.builder()
         .user(reviewer)
         .notificationType(NotificationType.COMMENT_ADDED)
@@ -172,6 +168,10 @@ public class NotificationService {
         .build();
 
     notificationRepository.save(notification);
+
+    NotificationDTO notificationDTO = new NotificationDTO(
+        notification.getId(),"comment", NotificationType.COMMENT_ADDED.getMessage(), reviewId
+    );
 
     log.info("댓글이 달렸다는 알림 전송 완료 ");
     sendNotification(reviewer.getId(), notificationDTO);
@@ -196,10 +196,6 @@ public class NotificationService {
       return;
     }
 
-    NotificationDTO notificationDTO = new NotificationDTO(
-        "like", NotificationType.LIKE_ADDED.getMessage(), reviewId
-    );
-
     Notification notification = Notification.builder()
         .user(reviewer)
         .notificationType(NotificationType.LIKE_ADDED)
@@ -208,6 +204,11 @@ public class NotificationService {
         .build();
 
     notificationRepository.save(notification);
+
+    NotificationDTO notificationDTO = new NotificationDTO(
+        notification.getId(), "like", NotificationType.LIKE_ADDED.getMessage(), reviewId
+    );
+
     log.info("좋아요가 달렸다는 알림 전송 완료");
 
     sendNotification(reviewer.getId(), notificationDTO);
@@ -235,9 +236,6 @@ public class NotificationService {
       message = "인증이 거절되었습니다.";
     }
 
-    NotificationDTO notificationDTO = new NotificationDTO(
-        "certification", message, certificationId);
-
     Notification notification = Notification.builder()
         .user(user)
         .notificationType(NotificationType.CERTIFICATION_RESULT)
@@ -247,6 +245,9 @@ public class NotificationService {
 
     notificationRepository.save(notification);
     log.info("인증 결과 알림 전송");
+
+    NotificationDTO notificationDTO = new NotificationDTO(
+       notification.getId(), "certification", message, certificationId);
 
     sendNotification(user.getId(), notificationDTO);
   }
@@ -291,6 +292,20 @@ public class NotificationService {
   /**
    * 전체 알림 읽음 처리
    */
+  public void markAllNotificationAsRead() {
+    User user = userService.getLoginUser();
+    log.info("전체 알림 읽음 시도 : userId = {}", user.getId());
 
+    List<Notification> notifications = notificationRepository.findByUser_IdAndIsReadFalseOrderByCreatedAtDesc(user.getId());
+
+    if (notifications.isEmpty()) {
+      log.info("읽지 않은 알림이 더이상 없습니다");
+      return;
+    }
+
+      notifications.forEach(Notification::markAsRead);
+      notificationRepository.saveAll(notifications);
+      log.info("전체 알림 읽음 처리 완료");
+  }
 
 }


### PR DESCRIPTION
# [변경사항]

1. 인증 상태가 PENDING/REJECTED 인 사용자가 사용하는 조회, 수정, 삭제 API를 구현했습니다. 
APPROVED 된 사용자는 이용할 수 없습니다. 

2. 전체 알림 읽음처리 API를 추가했습니다. 

3. 실시간 알림을 받을 때, notificationId를 추가적으로 반환하도록 했습니다. 

4. 특정 인증샷 확인 기능을 삭제했습니다. 
인증 목록 조회 기능과 중복되어 삭제하고, FE 쪽에서 url을 받아 모달로 사진만 띄울 예정입니다. 

5. 투표 결과 엔드포인트를 화이트리스트에 추가하여 토큰 없이 조회 가능하도록 수정했습니다. 
6. 인증된 사용자가 아니더라도 인증 리뷰에 댓글을 달 수 있도록 기존의 코드를 삭제했습니다. 


# [이후 예정 작업]
- 알림 전체 읽음처리 API 추가 