### PR TITLE
Fix : 엑세스토큰 없이 요청시, HttpStatus를 403에서 401로 변경

### DIFF
--- a/ddv/src/main/java/community/ddv/global/component/JwtAuthenticationEntryPoint.java
+++ b/ddv/src/main/java/community/ddv/global/component/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package community.ddv.global.component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException {
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 반환
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    String jsonResponse = "{\"error\": \"인증이 필요합니다. 엑세스 토큰을 포함해주세요.\"}";
+    response.getWriter().write(jsonResponse);
+  }
+}

--- a/ddv/src/main/java/community/ddv/global/component/JwtFilter.java
+++ b/ddv/src/main/java/community/ddv/global/component/JwtFilter.java
@@ -1,6 +1,8 @@
 package community.ddv.global.component;
 
 import community.ddv.global.constant.Role;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,24 +32,30 @@ public class JwtFilter extends OncePerRequestFilter {
   public static final String TOKEN_PREFIX = "Bearer ";
 
   @Override
-  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain)
       throws ServletException, IOException {
 
     String token = extractToken(request);
+    try {
+      if (token != null) {
+        String email = jwtProvider.extractEmail(token);
+        jwtProvider.validateToken(token, email);
+        Role role = jwtProvider.getRoleFromToken(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
+            Collections.singletonList(new SimpleGrantedAuthority(role.name())));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      }
 
-    // jwt 토큰이 있고 유효한 경우, 인증 처리
-    if (token != null && jwtProvider.validateToken(token, jwtProvider.extractEmail(token))) {
-      String email = jwtProvider.extractEmail(token);
-      Role role = jwtProvider.getRoleFromToken(token);
-      UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-      Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
-          Collections.singletonList(new SimpleGrantedAuthority(role.name())));
-      SecurityContextHolder.getContext().setAuthentication(authentication);
+      filterChain.doFilter(request, response);
+    } catch (ExpiredJwtException e) {
+      log.warn("만료된 JWT 토큰: {}", e.getMessage());
+      setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "토큰이 만료되었습니다.");
+    } catch (JwtException e) {
+      log.warn("잘못된 JWT 토큰: {}", e.getMessage());
+      setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
     }
-//    else {
-//      log.error("유효하지 않은 토큰");
-//    }
-    filterChain.doFilter(request, response);
   }
 
   private String extractToken(HttpServletRequest request) {
@@ -58,5 +66,11 @@ public class JwtFilter extends OncePerRequestFilter {
     }
     // 토큰이 존재하지 않거나, "Bearer "로 시작하지 않는 경우 null 반환
     return null;
+  }
+
+  private void setErrorResponse(HttpServletResponse response, int status, String message) throws IOException {
+    response.setStatus(status);
+    response.setContentType("application/json; charset=UTF-8"); // JSON + UTF-8 인코딩 설정
+    response.getWriter().write("{\"error\": \"" + message + "\"}");
   }
 }

--- a/ddv/src/main/java/community/ddv/global/component/JwtProvider.java
+++ b/ddv/src/main/java/community/ddv/global/component/JwtProvider.java
@@ -3,6 +3,7 @@ package community.ddv.global.component;
 import community.ddv.global.constant.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import jakarta.annotation.PostConstruct;
 import java.util.Date;
@@ -83,25 +84,23 @@ public class JwtProvider {
   }
 
   // 토큰 유효성 검사
-  public boolean validateToken(String token, String email) {
+  public void validateToken(String token, String email) {
 
     try {
       String extractedEmail = extractEmail(token);
-
       if (!extractedEmail.equals(email)) {
-        log.warn("토큰 유효성 검사 실패");
-        return false;
+        throw new JwtException("유효하지 않은 토큰입니다.");
       }
 
       if (isTokenExpired(token)) {
-        log.warn("만료된 토큰");
-        return false;
+        throw new ExpiredJwtException(null, null, "만료된 토큰입니다.");
       }
-      return true;
-
     } catch (ExpiredJwtException e) {
-      log.error("JWT 토큰 검증 실패" + e.getMessage());
-      return false;
+      log.warn("JWT 토큰 만료" + e.getMessage());
+      throw e;
+    } catch (JwtException e) {
+      log.warn("JWT 토큰 검증 실패" + e.getMessage());
+      throw e;
     }
   }
 

--- a/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package community.ddv.global.config;
 
+import community.ddv.global.component.JwtAuthenticationEntryPoint;
 import community.ddv.global.component.JwtFilter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +47,7 @@ public class SecurityConfig {
   };
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity, JwtFilter jwtFilter)
+  public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity, JwtFilter jwtFilter, JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint)
       throws Exception {
 
     return httpSecurity
@@ -60,12 +61,11 @@ public class SecurityConfig {
             .requestMatchers(HttpMethod.GET, "/api/reviews/{reviewId}/comments").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/reviews/movie/{tmdbId}").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/reviews/latest").permitAll()
-            .requestMatchers(HttpMethod.POST, "/api/votes").hasAuthority("ADMIN") // 관리자만 투표 생성 가능
-            .requestMatchers(HttpMethod.GET, "/api/certifications/admin/**").hasAuthority("ADMIN")
-            .requestMatchers(HttpMethod.POST, "/api/certifications/admin/**").hasAuthority("ADMIN")
             .anyRequest().authenticated()
         )
-        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class) // jwt 필터
+        .exceptionHandling(exception ->
+            exception.authenticationEntryPoint(jwtAuthenticationEntryPoint)) // 401 처리
+        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }
 

--- a/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
@@ -53,7 +53,7 @@ public enum ErrorCode {
   ALREADY_APPROVED("이미 승인되었습니다.", HttpStatus.BAD_REQUEST),
 
   // 토론 관련 에러코드
-  NOT_CERTIFIED_YET("토론 작성 권한이 없습니다. 인증을 먼저 완료해주세요", HttpStatus.UNAUTHORIZED),
+  NOT_CERTIFIED_YET("토론 작성 권한이 없습니다. 인증을 먼저 완료해주세요", HttpStatus.FORBIDDEN),
   INVALID_REVIEW_PERIOD("토론 작성 기간이 아닙니다. 다음 주에 새로운 영화로 만나요", HttpStatus.BAD_REQUEST),
 
   // 알림 관련 에러코드


### PR DESCRIPTION
# [변경사항]

1. 토큰 관련한 예외 처리를 수정했습니다. 
    - 헤더에 토큰을 넣지 않을 시, 만료 됐을 시 예외 메시지와 함께 401 에러가 반환됩니다.  
2. 관리자만 가능한 기능(투표 생성, 인증 확인/처리)은 예외 메시지와 함께 403 에러가 반환됩니다. 
