### PR TITLE
Fix : 인증샷 수정 시 rejectionReason이 null로 나오도록 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/controller/DiscussionController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/DiscussionController.java
@@ -46,8 +46,6 @@ public class DiscussionController {
   @GetMapping("/this-week-movie")
   public ResponseEntity<Map<String, Long>> getThisWeekMovie() {
     Long tmdbId = voteService.getLastWeekTopVoteMovie();
-    Map<String, Long> response = new HashMap<>();
-    response.put("TmdbId", tmdbId);
-    return ResponseEntity.ok(response);
+    return ResponseEntity.ok(Map.of("tmdbId", tmdbId));
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/board/service/CommentService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/CommentService.java
@@ -33,7 +33,6 @@ public class CommentService {
 
     log.info("댓글 작성 요청");
     User user = userService.getLoginUser();
-    log.info("댓글 작성자 : {}", user.getId());
 
     Review review = reviewRepository.findById(reviewId)
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
@@ -73,7 +72,6 @@ public class CommentService {
     }
 
     comment.updateContent(commentRequestDto.getContent());
-    log.info("댓글 수정 완료 - 댓글 ID : {}", comment.getId());
 
     return convertToCommentResponse(comment);
   }
@@ -101,7 +99,6 @@ public class CommentService {
       throw new DeepdiviewException(ErrorCode.COMMENT_NOT_BELONG_TO_REVIEW);
     }
 
-    log.info("댓글 삭제 완료 - 댓글 ID : {}", comment.getId());
     commentRepository.delete(comment);
   }
 
@@ -113,7 +110,6 @@ public class CommentService {
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
 
     Page<Comment> comments = commentRepository.findByReview(review, pageable);
-    log.info("댓글 조회 성공");
 
     return comments.map(this::convertToCommentResponse);
   }
@@ -124,7 +120,6 @@ public class CommentService {
     userService.getLoginUser();
 
     Page<Comment> comments = commentRepository.findByUser_Id(userId, pageable);
-    log.info("특정 이용자가 작성한 댓글 조회 성공");
 
     return comments.map(this::convertToCommentResponse);
   }

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -81,7 +81,6 @@ public class ReviewService {
       throw new DeepdiviewException(ErrorCode.INVALID_USER);
     }
     reviewRepository.delete(review);
-    log.info("리뷰 삭제 완료 - 리뷰 ID: {}", reviewId);
   }
 
   /**
@@ -174,7 +173,6 @@ public class ReviewService {
       reviews = reviewRepository.findByUser_Id(userId, pageable);
     }
 
-    log.info("특정 사용자의 리뷰 내역 조회 성공");
     return reviews.map(this::convertToReviewResponseDto);
 
   }

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -40,7 +40,6 @@ public class CertificationService {
   public CertificationResponseDto submitCertification(MultipartFile certificationImageFile) {
 
     User user = userService.getLoginUser();
-    log.info("인증샷 업로드 시도 : userId = {}", user.getId());
 
     if (LocalDateTime.now().getDayOfWeek() == DayOfWeek.SUNDAY) {
       log.warn("일요일에는 인증샷 제출 불가");
@@ -80,7 +79,6 @@ public class CertificationService {
   @Transactional(readOnly = true)
   public CertificationResponseDto getMyCertification() {
     User user = userService.getLoginUser();  // 로그인된 사용자 정보 가져오기
-    log.info("인증샷 조회 시도 : userId = {}", user.getId());
 
     // 사용자가 제출한 인증샷 조회
     Certification certification = certificationRepository.findByUser_Id(user.getId())
@@ -90,7 +88,7 @@ public class CertificationService {
     if (!certification.getStatus().equals(CertificationStatus.APPROVED)) {
       return convertToCertificationDto(certification);
     }
-    log.error("승인된 사용자는 자신의 상태를 조회할 필요가 없습니다.");
+    log.warn("승인된 사용자는 자신의 상태를 조회할 필요가 없습니다.");
     throw new DeepdiviewException(ErrorCode.ALREADY_APPROVED);
   }
 
@@ -101,7 +99,6 @@ public class CertificationService {
   public CertificationResponseDto updateCertification(MultipartFile certificationImageFile) {
 
     User user = userService.getLoginUser();
-    log.info("인증샷 수정 시도 : userId = {}", user.getId());
 
     if (LocalDateTime.now().getDayOfWeek() == DayOfWeek.SUNDAY) {
       log.warn("일요일에는 인증샷 수정이 불가");
@@ -150,7 +147,6 @@ public class CertificationService {
   public void deleteCertification() {
 
     User user = userService.getLoginUser();
-    log.info("인증샷 삭제 시도 : userId = {}", user.getId());
 
     // 인증샷 조회
     Certification certification = certificationRepository.findByUser_Id(user.getId())

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -138,6 +138,7 @@ public class CertificationService {
         .userId(updatedCertification.getUser().getId())
         .certificationUrl(updatedCertification.getCertificationUrl())
         .status(updatedCertification.getStatus())
+        .rejectionReason(null)
         .createdAt(updatedCertification.getCreatedAt())
         .build();
   }

--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
@@ -96,7 +96,7 @@ public class MovieService {
 
     Movie movie = movieRepository.findByTmdbId(tmdbId)
         .orElseThrow(() -> {
-          log.warn("영화 Id {}에 해당하는 영화가 없습니다.", tmdbId);
+          log.warn("영화 Id '{}'에 해당하는 영화가 없습니다.", tmdbId);
           return new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND);
         });
     Pageable pageable = PageRequest.of(0, 5, Sort.by(Direction.DESC, "createdAt"));

--- a/ddv/src/main/java/community/ddv/domain/user/constant/Role.java
+++ b/ddv/src/main/java/community/ddv/domain/user/constant/Role.java
@@ -2,5 +2,6 @@ package community.ddv.domain.user.constant;
 
 public enum Role {
 
-  USER, ADMIN
+  USER,
+  ADMIN
 }

--- a/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
@@ -22,7 +22,6 @@ public class ProfileImageService {
   @Transactional
   public String uploadProfileImage(MultipartFile profileImage) {
     User user = userService.getLoginUser();
-    log.info("프로필사진 등록 요청");
 
     String profileImageUrl = fileStorageService.uploadFile(profileImage);
     log.info("S3에 프로필 이미지 업로드 완료");

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -56,14 +56,17 @@ public class UserService {
 
     // 같은 이메일로 중복 회원가입 불가
     if (userRepository.findByEmail(signUpDto.getEmail()).isPresent()) {
+      log.warn("중복 회원가입 불가");
       throw new DeepdiviewException(ErrorCode.ALREADY_EXIST_MEMBER);
     }
     // 비밀번호 확인 로직 통과 여부
     if (!signUpDto.getPassword().equals(signUpDto.getConfirmPassword())) {
+      log.warn("비밀번호 확인 로직 통과 X");
       throw new DeepdiviewException(ErrorCode.NOT_VALID_PASSWORD);
     }
     // 중복 닉네임 사용불가
     if (userRepository.findByNickname(signUpDto.getNickname()).isPresent()) {
+      log.warn("중복 닉네임 불가");
       throw new DeepdiviewException(ErrorCode.ALREADY_EXIST_NICKNAME);
     }
 
@@ -221,15 +224,12 @@ public class UserService {
         log.info("이미 존재하는 닉네임이 있어 해당 닉네임으로 변경 불가");
         throw new DeepdiviewException(ErrorCode.ALREADY_EXIST_NICKNAME);
       }
-
       // 존재하지 않는 닉네임일 시, 닉네임 변경 성공
       user.updateNickname(newNickname);
-      log.info("닉네임 변경성공");
     }
 
     if (!newPassword.isBlank()) {
       log.info("비밀번호 변경시도");
-
       if (!isValidPassword(newPassword)) {
         throw new DeepdiviewException(ErrorCode.NOT_ENOUGH_PASSWORD);
       } else {
@@ -237,14 +237,10 @@ public class UserService {
           throw new DeepdiviewException(ErrorCode.NOT_VALID_PASSWORD);
         }
       }
-
       user.updatePassword(passwordEncoder.encode(newPassword));
-      log.info("비밀번호 변경성공");
     }
 
-    //userRepository.save(user);
     log.info("회원정보 수정완료");
-
 
   }
 


### PR DESCRIPTION
# [변경사항]

1. 승인 거절되어 rejectionReason이 존재하는 경우, 인증샷을 수정 해도 rejectionReason이 계속 남아있는 문제가 생겼습니다. 
-> 인증샷 수정시 rejectionReason은 null로 반환되도록 수정했습니다. 
