### PR TITLE
Fix : 인증 승인거절 후 수정 시에도 거절 사유가 함께 나오는 문제, 자신의 인증상태 조회시 NPE 문제 해결

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/dto/ReviewResponseDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/board/dto/ReviewResponseDTO.java
@@ -20,7 +20,7 @@ public class ReviewResponseDTO {
   private String profileImageUrl;
   private String reviewTitle;
   private String reviewContent;
-  private double rating;
+  private Double rating;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
   private Integer likeCount;
@@ -28,7 +28,7 @@ public class ReviewResponseDTO {
   private Long tmdbId;
   private String movieTitle;
   private String posterPath;
-  private boolean certified;
+  private Boolean certified;
 
   private List<CommentResponseDto> comments;
 }

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -116,11 +116,9 @@ public class CertificationService {
 
     // 기존의 인증샷 S3에서 삭제
     fileStorageService.deleteFile(certification.getCertificationUrl());
-    log.info("기존의 인증샷 파일 S3에서 삭제 완료");
 
     // 새 인증샷 파일 업로드
     String newCertificationUrl = fileStorageService.uploadFile(certificationImageFile);
-    log.info("새로운 인증샷 파일 S3에 업로드 완료");
 
     // 인증샷 수정
     certification.setCertificationUrl(newCertificationUrl);
@@ -163,7 +161,6 @@ public class CertificationService {
 
     // S3에서 파일 삭제
     fileStorageService.deleteFile(certification.getCertificationUrl());
-    log.info("인증샷 파일 S3에서 삭제 완료");
 
     // DB에서 인증샷 삭제
     certificationRepository.delete(certification);
@@ -266,7 +263,6 @@ public class CertificationService {
     for(Certification certification : certifications) {
       try {
         fileStorageService.deleteFile(certification.getCertificationUrl());
-        log.info("인증샷 파일 S3에서 삭제 완료");
       } catch (RuntimeException e) {
         log.info("인증샷 파일을 S3에서 삭제 실패 : url = {}", certification.getCertificationUrl());
       }

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -85,11 +85,15 @@ public class CertificationService {
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND));
 
     // PENDING 또는 REJECTED 상태에서만 반환
-    if (!certification.getStatus().equals(CertificationStatus.APPROVED)) {
-      return convertToCertificationDto(certification);
+    CertificationStatus status = certification.getStatus();
+    if (status == null) {
+      throw new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND);
     }
-    log.warn("승인된 사용자는 자신의 상태를 조회할 필요가 없습니다.");
-    throw new DeepdiviewException(ErrorCode.ALREADY_APPROVED);
+    if (status.equals(CertificationStatus.APPROVED)) {
+      throw new DeepdiviewException(ErrorCode.ALREADY_APPROVED);
+    }
+
+    return convertToCertificationDto(certification);
   }
 
   /**

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -123,6 +123,7 @@ public class CertificationService {
     // 인증샷 수정
     certification.setCertificationUrl(newCertificationUrl);
     certification.setStatus(CertificationStatus.PENDING);
+    certification.setRejectionReason(null);
     certification.setCreatedAt(LocalDateTime.now());
 
     Certification updatedCertification = certificationRepository.save(certification);

--- a/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
@@ -22,12 +22,11 @@ public class ProfileImageService {
   @Transactional
   public String uploadProfileImage(MultipartFile profileImage) {
     User user = userService.getLoginUser();
+    log.info("프로필 사진 등록 요청");
 
     String profileImageUrl = fileStorageService.uploadFile(profileImage);
-    log.info("S3에 프로필 이미지 업로드 완료");
 
     user.updateProfileImageUrl(profileImageUrl);
-    log.info("프로필 이미지 등록 완료");
     return profileImageUrl;
   }
 
@@ -43,12 +42,12 @@ public class ProfileImageService {
     // 기존 프로필 삭제
     if (user.getProfileImageUrl() != null) {
       fileStorageService.deleteFile(user.getProfileImageUrl());
-      log.info("기존 프로필 사진 삭제 완료");
+      log.info("기존 프로필 사진 삭제");
     }
 
     String newProfileImageUrl = fileStorageService.uploadFile(profileImage);
     user.updateProfileImageUrl(newProfileImageUrl);
-    log.info("프로필 이미지 수정 완료");
+    log.info("프로필 이미지 수정");
 
     return newProfileImageUrl;
   }
@@ -66,7 +65,6 @@ public class ProfileImageService {
       fileStorageService.deleteFile(user.getProfileImageUrl());
 
       user.updateProfileImageUrl(null);
-      log.info("프로필 사진 삭제 완료");
     }
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import community.ddv.domain.board.repository.CommentRepository;
 import community.ddv.domain.board.repository.ReviewRepository;
 import community.ddv.domain.certification.Certification;
 import community.ddv.domain.certification.CertificationRepository;
+import community.ddv.domain.certification.constant.RejectionReason;
 import community.ddv.domain.user.dto.LoginResponse;
 import community.ddv.domain.user.dto.UserDTO.AccountDeleteDto;
 import community.ddv.domain.user.dto.UserDTO.AccountUpdateDto;
@@ -315,6 +316,11 @@ public class UserService {
         ));
 
     Certification certification = certificationRepository.findByUser_Id(user.getId()).orElse(null);
+    CertificationStatus certificationStatus = certification != null ?
+        certification.getStatus() : null;
+    RejectionReason rejectionReason = certification != null && certification.getStatus() == CertificationStatus.REJECTED ?
+        certification.getRejectionReason() : null;
+
 
     return UserInfoDto.builder()
         .nickname(user.getNickname())
@@ -324,9 +330,8 @@ public class UserService {
         .reviewCount(reviewCount)
         .commentCount(commentCount)
         .ratingDistribution(ratingDistribution)
-        .certificationStatus(certification != null ? certification.getStatus() : null)
-        .rejectionReason(certification != null && certification.getStatus() == CertificationStatus.REJECTED
-        ? certification.getRejectionReason() : null)
+        .certificationStatus(certificationStatus)
+        .rejectionReason(rejectionReason)
     .build();
   }
 

--- a/ddv/src/main/java/community/ddv/global/fileUpload/FileStorageService.java
+++ b/ddv/src/main/java/community/ddv/global/fileUpload/FileStorageService.java
@@ -71,6 +71,7 @@ public class FileStorageService {
     try (InputStream inputStream = file.getInputStream()) {
       PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, fileName, inputStream, metadata);
       amazonS3.putObject(putObjectRequest);
+      log.info("S3에 파일 업로드 성공");
     } catch (IOException e) {
       log.error("파일 업로드 중 IOException 발생: {}", e.getMessage());
       throw new DeepdiviewException(ErrorCode.FILE_UPLOAD_FAILED);


### PR DESCRIPTION
# [변경사항]

1. 인증 승인이 거절 된 후 수정할 때에 rejectedReason이 null로 나오도록 수정했습니다.
2. 인증을 하지 않은 상태에서 자신의 인증상태 조회시,  NPE 발생 -> 예외 처리 하였습니다. 