### PR TITLE
Fix : 파라미터가 잘못된 타입으로 들어간 경우, 401 에러가 뜨는 이슈 해결

### DIFF
--- a/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
@@ -58,7 +58,10 @@ public enum ErrorCode {
   INVALID_REVIEW_PERIOD("토론 작성 기간이 아닙니다. 다음 주에 새로운 영화로 만나요", HttpStatus.BAD_REQUEST),
 
   // 알림 관련 에러코드
-  NOTIFICATION_NOT_FOUND("존재하지 않는 알람입니다.", HttpStatus.NOT_FOUND);
+  NOTIFICATION_NOT_FOUND("존재하지 않는 알람입니다.", HttpStatus.NOT_FOUND),
+
+  // 형변환 관련 에러코드
+  INVALID_INPUT_VALUE("입력값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
 
   private final String description;
   private final HttpStatus httpStatus;

--- a/ddv/src/main/java/community/ddv/global/exception/GlobalExceptionHandler.java
+++ b/ddv/src/main/java/community/ddv/global/exception/GlobalExceptionHandler.java
@@ -12,13 +12,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
-import org.springframework.web.servlet.View;
 
 @RestControllerAdvice
 @AllArgsConstructor
 public class GlobalExceptionHandler {
-
-  private final View error;
 
   @ExceptionHandler(DeepdiviewException.class)
   public ResponseEntity<ErrorResponse> handleDeepdiviewException(DeepdiviewException e) {

--- a/ddv/src/main/java/community/ddv/global/exception/GlobalExceptionHandler.java
+++ b/ddv/src/main/java/community/ddv/global/exception/GlobalExceptionHandler.java
@@ -10,11 +10,15 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.View;
 
 @RestControllerAdvice
 @AllArgsConstructor
 public class GlobalExceptionHandler {
+
+  private final View error;
 
   @ExceptionHandler(DeepdiviewException.class)
   public ResponseEntity<ErrorResponse> handleDeepdiviewException(DeepdiviewException e) {
@@ -44,6 +48,14 @@ public class GlobalExceptionHandler {
       errors.put(fieldName, errorMessage);
     });
     return ResponseEntity.badRequest().body(errors);
+  }
+
+  // 타입 유형 예외 처리
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+    ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+    ErrorResponse errorResponse = new ErrorResponse(errorCode.name(), errorCode.getDescription());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
   }
 
   @ExceptionHandler(MaxUploadSizeExceededException.class)


### PR DESCRIPTION
# [변경사항]

-  Long 타입 파라미터에 String 을 넣었을 때 401(Unauthorized) 에러 발생 문제 해결 
    - '/api/reviews/문자'  요청시,  인증이 필요한 다른 엔드포인트로 매핑되어 401 리턴이 된 것
    
-  GlobalExceptionHandler에 형변환 예외(MethodArgumentTypeMismatchException)를 추가
    - 형변환 실패시  예외 처리
    
- 형변환 오류이므로 404(Not Found)가 아닌 400 (Bad Request)로 반환 