### PR TITLE
Fix : NonUniqueResultException 예외 해결, Feat : 디폴트 프로필사진 설정 추가 

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ https://github.com/user-attachments/assets/d3e371d5-d93e-41f9-94f6-cf885f38626e
 -----
 ## 🌐 배포 주소
 
-- BE: https://deepdiview.site
-- FE: https://deepdiview.vercel.app
+- BE: 
+- FE: 
 - API 문서화 : [Swagger](https://deepdiview.site/swagger-ui/index.html)
 
 

--- a/ddv/src/main/java/community/ddv/domain/user/constant/ProfileImageConstant.java
+++ b/ddv/src/main/java/community/ddv/domain/user/constant/ProfileImageConstant.java
@@ -1,0 +1,5 @@
+package community.ddv.domain.user.constant;
+
+public class ProfileImageConstant {
+  public static final String DEFAULT_PROFILE_IMAGE_URL = "https://deepdiview.s3.ap-northeast-2.amazonaws.com/defaultprofile.png";
+}

--- a/ddv/src/main/java/community/ddv/domain/user/entity/User.java
+++ b/ddv/src/main/java/community/ddv/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package community.ddv.domain.user.entity;
 
+import community.ddv.domain.user.constant.ProfileImageConstant;
 import community.ddv.domain.user.constant.Role;
 import community.ddv.domain.certification.Certification;
 import community.ddv.domain.board.entity.Comment;
@@ -12,10 +13,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +50,14 @@ public class User {
   private Role role;
 
   private String profileImageUrl;
+
+  @PrePersist
+  public void prePersist() {
+    if (profileImageUrl == null || profileImageUrl.isBlank()) {
+      profileImageUrl = ProfileImageConstant.DEFAULT_PROFILE_IMAGE_URL;
+    }
+  }
+
   private String oneLineIntroduction;
 
   @CreatedDate
@@ -55,27 +66,27 @@ public class User {
   private LocalDateTime updatedAt;
 
 
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @Builder.Default
   private List<Review> reviews = new ArrayList<>();
 
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @Builder.Default
   private List<Comment> comments = new ArrayList<>();
 
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @Builder.Default
   private List<Like> likes = new ArrayList<>();
 
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @Builder.Default
   private List<Certification> certifications = new ArrayList<>();
 
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @Builder.Default
   private List<VoteParticipation> voteParticipations = new ArrayList<>();
 
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @Builder.Default
   private List<Notification> notifications = new ArrayList<>();
 
@@ -90,10 +101,6 @@ public class User {
 
   public void updateProfileImageUrl(String newProfileImageUrl) {
     this.profileImageUrl = newProfileImageUrl;
-  }
-
-  public void deleteProfileImageUrl(){
-    this.profileImageUrl = null;
   }
 
   public void updateOneLineIntroduction(String newOneLineIntroduction) {

--- a/ddv/src/main/java/community/ddv/domain/user/repository/UserRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/user/repository/UserRepository.java
@@ -10,6 +10,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
   Optional<User> findByNickname(String nickname);
 
-  boolean existsByRole(Role role);
-
 }

--- a/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
@@ -1,5 +1,6 @@
 package community.ddv.domain.user.service;
 
+import community.ddv.domain.user.constant.ProfileImageConstant;
 import community.ddv.domain.user.entity.User;
 import community.ddv.global.fileUpload.FileStorageService;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +33,9 @@ public class ProfileImageService {
 
   /**
    * 프로필 수정
+   *
    * @param profileImage
-   * */
+   */
   @Transactional
   public String updateProfileImage(MultipartFile profileImage) {
     User user = userService.getLoginUser();
@@ -60,11 +62,13 @@ public class ProfileImageService {
     User user = userService.getLoginUser();
     log.info("프로필사진 삭제 요청");
 
-    if (user.getProfileImageUrl() != null && !user.getProfileImageUrl().isEmpty()) {
+    if (user.getProfileImageUrl() != null && !user.getProfileImageUrl().isEmpty()
+        && !user.getProfileImageUrl().equals(ProfileImageConstant.DEFAULT_PROFILE_IMAGE_URL)) {
 
       fileStorageService.deleteFile(user.getProfileImageUrl());
-
-      user.deleteProfileImageUrl();
+      log.info("기존 프로필 사진 삭제");
     }
+    user.updateProfileImageUrl(ProfileImageConstant.DEFAULT_PROFILE_IMAGE_URL);
+    log.info("기본 프로필로 초기화");
   }
 }


### PR DESCRIPTION
# [변경사항]

1. JPA가 내부적으로 JOIN을 하면서 row 중복이 생기기면서 결과가 2개 이상 나오게 되면서 에러 발생한 것으로 보여 User 엔티티와 연관관계에 있는 List들에 fetch = FetchType.LAZY 명시
2. 디폴트 프로필 사진을 넣어두었습니다. 
    - 회원가입 시 자동으로 들어가며, 등록/수정은 이전과 같이 수행할 수 있습니다. 
    - 프로필 사진 삭제시, 다시 디폴트 프로필 사진으로 초기화됩니다. 

