### PR TITLE
Fix : Ceritification 중복으로 인한 NonUniqueResultException 예외 해결 2

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationRepository.java
@@ -21,6 +21,7 @@ public interface CertificationRepository extends JpaRepository<Certification, Lo
   int resetAllCertifications();
 
   Optional<Certification> findByUser_Id(Long userId);
+  Optional<Certification> findTopByUser_IdOrderByCreatedAtDesc(Long userId);
 
   Page<Certification> findByStatusIsNotNull(Pageable pageable);
 }

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -81,7 +81,7 @@ public class CertificationService {
     User user = userService.getLoginUser();  // 로그인된 사용자 정보 가져오기
 
     // 사용자가 제출한 인증샷 조회
-    Certification certification = certificationRepository.findByUser_Id(user.getId())
+    Certification certification = certificationRepository.findTopByUser_IdOrderByCreatedAtDesc(user.getId())
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND));
 
     // PENDING 또는 REJECTED 상태에서만 반환
@@ -110,7 +110,7 @@ public class CertificationService {
     }
 
     // 이미 인증 승인을 받은 경우, 수정 불가
-    Certification certification = certificationRepository.findByUser_Id(user.getId())
+    Certification certification = certificationRepository.findTopByUser_IdOrderByCreatedAtDesc(user.getId())
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND));
 
     if (certification.getStatus() == CertificationStatus.APPROVED) {
@@ -152,7 +152,7 @@ public class CertificationService {
     User user = userService.getLoginUser();
 
     // 인증샷 조회
-    Certification certification = certificationRepository.findByUser_Id(user.getId())
+    Certification certification = certificationRepository.findTopByUser_IdOrderByCreatedAtDesc(user.getId())
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND));
 
     // 이미 승인 받은 상태면 삭제 불가

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -315,7 +315,7 @@ public class UserService {
             Collectors.counting()
         ));
 
-    Certification certification = certificationRepository.findByUser_Id(user.getId()).orElse(null);
+    Certification certification = certificationRepository.findTopByUser_IdOrderByCreatedAtDesc(user.getId()).orElse(null);
     CertificationStatus certificationStatus =
         certification != null ?
         certification.getStatus() : null;


### PR DESCRIPTION

# [변경사항]

1. 인증이 여러 개 들어가면 1개만 가져올 수 없게 되어 예외가 터지게 된 것 확인 후, 가장 최근의 데이터만 가져올 수 있도록 수정했습니다.
