### PR TITLE
Refactor :  회원정보 수정 로직 보완, 유효성 검사 추가 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
@@ -52,7 +52,7 @@ public class CommentController {
   ) {
     CommentResponseDto commentResponseDto = commentService.updateComment(reviewId, commentId,
         commentRequestDto);
-    return ResponseEntity.status(HttpStatus.OK).body(commentResponseDto);
+    return ResponseEntity.ok(commentResponseDto);
   }
 
   @Operation(summary = "댓글 삭제", description = "리뷰 id와 댓글 id가 정확히 매칭되어야 삭제됩니다. 댓글 작성자만 삭제 가능")

--- a/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
@@ -60,9 +60,7 @@ public class ReviewController {
       @PathVariable Long reviewId,
       @RequestBody @Valid ReviewDTO.ReviewUpdateDTO reviewUpdateDTO
   ) {
-    ReviewResponseDTO response = reviewService.updateReview(reviewId, reviewUpdateDTO);
-    return ResponseEntity.ok(response);
-
+    return ResponseEntity.ok(reviewService.updateReview(reviewId, reviewUpdateDTO));
   }
 
   @Operation(summary = "특정 영화에 대한 리뷰 조회", description = "댓글은 포함되어있지 않습니다. ?sortBy=likeCount로 좋아요 순 정렬을 할 수 있습니다." )
@@ -83,16 +81,14 @@ public class ReviewController {
 
     Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
 
-    Page<ReviewResponseDTO> reviews = reviewService.getReviewByMovieId(tmdbId, sortedPageable, certifiedFilter);
-    return ResponseEntity.ok(reviews);
+    return ResponseEntity.ok(reviewService.getReviewByMovieId(tmdbId, sortedPageable, certifiedFilter));
   }
 
   @Operation(summary = "특정 리뷰 조회", description = "댓글이 포함되어 있습니다.")
   @GetMapping("/{reviewId}")
   public ResponseEntity<ReviewResponseDTO> getReviewById(
       @PathVariable Long reviewId) {
-    ReviewResponseDTO reviews = reviewService.getReviewById(reviewId);
-    return ResponseEntity.ok(reviews);
+    return ResponseEntity.ok(reviewService.getReviewById(reviewId));
   }
 
   @Operation(summary = "최신 리뷰 3개 조회")

--- a/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
@@ -106,6 +106,6 @@ public class ReviewController {
   public ResponseEntity<Void> toggleLike(
       @PathVariable Long reviewId) {
     likeService.toggleLike(reviewId);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationController.java
@@ -65,9 +65,9 @@ public class CertificationController {
   public ResponseEntity<Page<CertificationResponseDto>> getPendingCertifications(
       @RequestParam(required = false) CertificationStatus status,
       @PageableDefault(size = 10, page = 0, sort = "createdAt", direction = Direction.ASC) Pageable pageable) {
-    Page<CertificationResponseDto> certifications = certificationService.getCertificationsByStatus(
-        status, pageable);
-    return ResponseEntity.status(HttpStatus.OK).body(certifications);
+    Page<CertificationResponseDto> certifications =
+        certificationService.getCertificationsByStatus(status, pageable);
+    return ResponseEntity.ok(certifications);
   }
 
 

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
@@ -43,14 +43,14 @@ public class NotificationController {
   public ResponseEntity<Void> markNotificationAsRead(
       @PathVariable Long notificationId) {
     notificationService.markNotificationAsRead(notificationId);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   @Operation(summary = "전체 알림 읽음처리")
   @PutMapping("/read-all")
   public ResponseEntity<Void> markAllNotificationAsRead() {
     notificationService.markAllNotificationAsRead();
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
 }

--- a/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
+++ b/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
@@ -52,7 +52,7 @@ public class UserController {
   @PostMapping("/signup")
   public ResponseEntity<Void> signup(@RequestBody @Valid UserDTO.SignUpDto signUpDto) {
     userService.signUp(signUpDto);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   // 로그인 API
@@ -99,7 +99,7 @@ public class UserController {
       @RequestBody AccountUpdateDto accountUpdateDto
   ) {
     userService.updateAccount(accountUpdateDto);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   @Operation(summary = "한줄소개 설정/수정", description = "회원가입 직후에는 새롭게 설정, 설정된 이후에는 수정")
@@ -108,7 +108,7 @@ public class UserController {
       @RequestBody OneLineIntro oneLineIntro
   ) {
     userService.updateOneLineIntro(oneLineIntro);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   @Operation(summary = "내 정보 확인", description = "닉네임, 이메일, 프로필사진, 한줄소개, 리뷰수, 댓글수, 별점 분포")

--- a/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
+++ b/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
@@ -8,7 +8,7 @@ import community.ddv.domain.user.dto.UserDTO.AccountDeleteDto;
 import community.ddv.domain.user.dto.UserDTO.AccountUpdateDto;
 import community.ddv.domain.user.dto.UserDTO.OneLineIntro;
 import community.ddv.domain.user.dto.UserDTO.TokenDto;
-import community.ddv.domain.user.dto.UserDTO.UserInfoDto;
+import community.ddv.domain.user.dto.UserDTO.UserInfoResponseDto;
 import community.ddv.domain.user.service.ProfileImageService;
 import community.ddv.domain.user.service.UserService;
 import community.ddv.domain.board.service.CommentService;
@@ -59,8 +59,7 @@ public class UserController {
   @Operation(summary = "로그인")
   @PostMapping("/login")
   public ResponseEntity<LoginResponse> login(@RequestBody @Valid UserDTO.LoginDto loginDto) {
-    LoginResponse loginResponse = userService.logIn(loginDto);
-    return ResponseEntity.ok(loginResponse);
+    return ResponseEntity.ok(userService.logIn(loginDto));
   }
 
   @Operation(summary = "로그아웃")
@@ -96,7 +95,7 @@ public class UserController {
   @Operation(summary = "회원정보 수정")
   @PutMapping("/me")
   public ResponseEntity<Void> updateAccount(
-      @RequestBody AccountUpdateDto accountUpdateDto
+      @RequestBody @Valid AccountUpdateDto accountUpdateDto
   ) {
     userService.updateAccount(accountUpdateDto);
     return ResponseEntity.noContent().build();
@@ -113,17 +112,15 @@ public class UserController {
 
   @Operation(summary = "내 정보 확인", description = "닉네임, 이메일, 프로필사진, 한줄소개, 리뷰수, 댓글수, 별점 분포")
   @GetMapping("/me")
-  public ResponseEntity<UserInfoDto> getMyInfo() {
-    UserInfoDto userInfoDto = userService.getMyInfo();
-    return ResponseEntity.ok(userInfoDto);
+  public ResponseEntity<UserInfoResponseDto> getMyInfo() {
+    return ResponseEntity.ok(userService.getMyInfo());
   }
 
   @Operation(summary = "다른 유저 정보 확인", description = "닉네임, 프로필사진, 한줄소개, 리뷰수, 댓글수, 별점 분포")
   @GetMapping("/{userId}")
-  public ResponseEntity<UserInfoDto> getOthersInfo(
+  public ResponseEntity<UserInfoResponseDto> getOthersInfo(
       @PathVariable Long userId) {
-    UserInfoDto userInfoDto = userService.getOthersInfo(userId);
-    return ResponseEntity.ok(userInfoDto);
+    return ResponseEntity.ok(userService.getOthersInfo(userId));
   }
 
   @Operation(summary = "특정 사용자가 작성한 댓글 조회")

--- a/ddv/src/main/java/community/ddv/domain/user/dto/UserDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/user/dto/UserDTO.java
@@ -55,6 +55,7 @@ public class UserDTO {
 
     private String newNickname;
 
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
     private String newPassword;
     private String newConfirmPassword;
   }
@@ -68,7 +69,7 @@ public class UserDTO {
   @AllArgsConstructor
   @NoArgsConstructor
   @Builder
-  public static class UserInfoDto {
+  public static class UserInfoResponseDto {
 
     private String nickname;
     private String email;

--- a/ddv/src/main/java/community/ddv/domain/vote/controller/VoteController.java
+++ b/ddv/src/main/java/community/ddv/domain/vote/controller/VoteController.java
@@ -39,23 +39,20 @@ public class VoteController {
   @Operation(summary = "현재 진행중인 투표의 선택지 조회", description = "현재 투표가 진행중일 때만 조회 가능합니다.")
   @GetMapping("/options")
   public ResponseEntity<VoteOptionsDto> getActivatingVote() {
-    VoteOptionsDto options = voteService.getVoteChoices();
-    return ResponseEntity.status(HttpStatus.OK).body(options);
+    return ResponseEntity.ok(voteService.getVoteChoices());
   }
 
   @Operation(summary = "현재 진행중인 투표에 참여하기")
   @PostMapping("/participate")
   public ResponseEntity<VoteParticipationResponseDto> participateVote(
       @Valid @RequestBody VoteParticipationRequestDto voteParticipationRequestDto) {
-    VoteParticipationResponseDto responseDTO = voteService.participateVote(voteParticipationRequestDto);
-    return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    return ResponseEntity.ok(voteService.participateVote(voteParticipationRequestDto));
   }
 
   @Operation(summary = "현재 진행중인 투표 결과 확인", description = "현재 투표가 진행중일 때만 결과 확인 가능합니다.")
   @GetMapping("/result")
   public ResponseEntity<VoteResultDTO> getVoteResult() {
-    VoteResultDTO voteResultDTO = voteService.getCurrentVoteResult();
-    return ResponseEntity.ok(voteResultDTO);
+    return ResponseEntity.ok(voteService.getCurrentVoteResult());
   }
 
   @Operation(summary = "투표 삭제", description = "관리자만 삭제 가능")
@@ -76,7 +73,6 @@ public class VoteController {
   @Operation(summary = "지난주 투표 전체 결과 조회", description = "지난주에 진행한 투표의 전체 결과를 볼 수 있습니다.")
   @GetMapping("/result/latest")
   public ResponseEntity<VoteResultDTO> getLatestVoteResult() {
-    VoteResultDTO voteResultDTO = voteService.getLatestVoteResult();
-    return ResponseEntity.ok(voteResultDTO);
+    return ResponseEntity.ok(voteService.getLatestVoteResult());
   }
 }

--- a/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
   ALREADY_EXIST_NICKNAME("이미 존재하는 닉네임입니다. 다른 닉네임을 작성해주세요", HttpStatus.BAD_REQUEST),
   NOT_VALID_PASSWORD("비밀번호가 일치하지 않습니다. 비밀번호를 다시 확인해주세요", HttpStatus.BAD_REQUEST),
   NOT_ENOUGH_PASSWORD("비밀번호는 8자 이상으로 설정해야 합니다.", HttpStatus.BAD_REQUEST),
+  EMPTY_PASSWORD("비밀번호를 확인해주세요", HttpStatus.BAD_REQUEST),
   USER_NOT_FOUND("존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
   INVALID_REFRESH_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST),
   UNAUTHORIZED("로그인되어 있지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),


### PR DESCRIPTION
# [변경사항]

1. Controller 반환형이 Void인 경우, 기존 200(OK) → 204(No Content)로 응답 코드 변경
2. Controller 전반에서 ResponseEntity 반환 방식 통일
3. 회원 정보 수정 로직 강화
    - 유효성 검사 : 비밀번호 8자 이상
 