### PR TITLE
Feat : 예외 응답 형태 수정, 회원정보 수정 API 분리, 비밀번호 유효성 검사 추가 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
@@ -80,8 +80,8 @@ public class ReviewController {
       : Sort.by(Sort.Order.by("createdAt").with(direction));
 
     Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
-
-    return ResponseEntity.ok(reviewService.getReviewByMovieId(tmdbId, sortedPageable, certifiedFilter));
+    Page<ReviewResponseDTO> reviews = reviewService.getReviewByMovieId(tmdbId, sortedPageable, certifiedFilter);
+    return ResponseEntity.ok(reviews);
   }
 
   @Operation(summary = "특정 리뷰 조회", description = "댓글이 포함되어 있습니다.")

--- a/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
+++ b/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
@@ -5,7 +5,6 @@ import community.ddv.domain.board.dto.ReviewResponseDTO;
 import community.ddv.domain.user.dto.LoginResponse;
 import community.ddv.domain.user.dto.UserDTO;
 import community.ddv.domain.user.dto.UserDTO.AccountDeleteDto;
-import community.ddv.domain.user.dto.UserDTO.AccountUpdateDto;
 import community.ddv.domain.user.dto.UserDTO.OneLineIntro;
 import community.ddv.domain.user.dto.UserDTO.TokenDto;
 import community.ddv.domain.user.dto.UserDTO.UserInfoResponseDto;
@@ -91,13 +90,23 @@ public class UserController {
     return ResponseEntity.ok(newAccessToken);
   }
 
-  // 회원정보 수정 API
-  @Operation(summary = "회원정보 수정")
-  @PutMapping("/me")
+  // 닉네임 수정 API
+  @Operation(summary = "닉네임 수정")
+  @PutMapping("/me/nickname")
   public ResponseEntity<Void> updateAccount(
-      @RequestBody @Valid AccountUpdateDto accountUpdateDto
+      @RequestBody @Valid UserDTO.NicknameUpdateDto nicknameUpdateDto
   ) {
-    userService.updateAccount(accountUpdateDto);
+    userService.updateNickname(nicknameUpdateDto);
+    return ResponseEntity.noContent().build();
+  }
+
+  // 비밀번호 수정 API
+  @Operation(summary = "비밀번호 수정")
+  @PutMapping("/me/password")
+  public ResponseEntity<Void> updateAccount(
+      @RequestBody @Valid UserDTO.PasswordUpdateDto passwordUpdateDto
+  ) {
+    userService.updatePassword(passwordUpdateDto);
     return ResponseEntity.noContent().build();
   }
 

--- a/ddv/src/main/java/community/ddv/domain/user/dto/UserDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/user/dto/UserDTO.java
@@ -21,8 +21,10 @@ public class UserDTO {
     @Email(message = "이메일 형식에 맞게 작성해주세요")
     private String email;
 
-    @NotBlank(message = "비밀번호를 입력해주세요")
-    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*\\d)[a-z\\d]{8,}$",
+        message = "영문 소문자와 숫자를 포함하여 8자 이상이어야 합니다."
+    )
     private String password;
 
     @NotBlank(message = "비밀번호를 확인해주세요")
@@ -64,7 +66,8 @@ public class UserDTO {
     @Pattern(
         regexp = "^(?=.*[a-z])(?=.*\\d)[a-z\\d]{8,}$",
         message = "영문 소문자와 숫자를 포함하여 8자 이상이어야 합니다."
-    )    private String newPassword;
+    )
+    private String newPassword;
 
     @NotBlank(message = "비밀번호를 확인해주세요")
     private String newConfirmPassword;

--- a/ddv/src/main/java/community/ddv/domain/user/dto/UserDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/user/dto/UserDTO.java
@@ -4,6 +4,7 @@ import community.ddv.domain.certification.constant.CertificationStatus;
 import community.ddv.domain.certification.constant.RejectionReason;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -51,12 +52,21 @@ public class UserDTO {
   }
 
   @Getter
-  public static class AccountUpdateDto {
-
+  public static class NicknameUpdateDto {
+    @NotBlank(message = "새로운 닉네임을 입력해주세요")
     private String newNickname;
 
-    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
-    private String newPassword;
+  }
+
+  @Getter
+  public static class PasswordUpdateDto {
+
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*\\d)[a-z\\d]{8,}$",
+        message = "영문 소문자와 숫자를 포함하여 8자 이상이어야 합니다."
+    )    private String newPassword;
+
+    @NotBlank(message = "비밀번호를 확인해주세요")
     private String newConfirmPassword;
   }
 

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -8,9 +8,10 @@ import community.ddv.domain.certification.CertificationRepository;
 import community.ddv.domain.certification.constant.RejectionReason;
 import community.ddv.domain.user.dto.LoginResponse;
 import community.ddv.domain.user.dto.UserDTO.AccountDeleteDto;
-import community.ddv.domain.user.dto.UserDTO.AccountUpdateDto;
+import community.ddv.domain.user.dto.UserDTO.NicknameUpdateDto;
 import community.ddv.domain.user.dto.UserDTO.LoginDto;
 import community.ddv.domain.user.dto.UserDTO.OneLineIntro;
+import community.ddv.domain.user.dto.UserDTO.PasswordUpdateDto;
 import community.ddv.domain.user.dto.UserDTO.SignUpDto;
 import community.ddv.domain.user.dto.UserDTO.TokenDto;
 import community.ddv.domain.user.dto.UserDTO.UserInfoResponseDto;
@@ -224,18 +225,15 @@ public class UserService {
   }
 
   /**
-   * 회원정보 수정 (닉네임, 비밀번호)
-   * @param accountUpdateDto
+   * 닉네임 수정
    */
   @Transactional
-  public void updateAccount(AccountUpdateDto accountUpdateDto) {
+  public void updateNickname(NicknameUpdateDto nicknameUpdateDto) {
 
     User user = getLoginUser();
-    log.info("회원정보 수정시도 : {}", user.getEmail());
+    log.info("닉네임 수정시도 : {}", user.getEmail());
 
-    String newNickname = accountUpdateDto.getNewNickname();
-    String newPassword = accountUpdateDto.getNewPassword();
-    String newConfirmPassword = accountUpdateDto.getNewConfirmPassword();
+    String newNickname = nicknameUpdateDto.getNewNickname();
 
     // 닉네임 변경 시도
     if (newNickname != null && !newNickname.isBlank()) {
@@ -248,15 +246,22 @@ public class UserService {
       }
       user.updateNickname(newNickname);
     }
+  }
+
+  @Transactional
+  public void updatePassword(PasswordUpdateDto passwordUpdateDto) {
+
+    User user = getLoginUser();
+    log.info("비밀번호 수정시도 : {}", user.getEmail());
+
+    String newPassword = passwordUpdateDto.getNewPassword();
+    String newConfirmPassword = passwordUpdateDto.getNewConfirmPassword();
 
     if ((newPassword != null && !newPassword.isBlank()) || (newConfirmPassword != null && !newConfirmPassword.isBlank())) {
       log.info("비밀번호 변경시도");
       // 둘 중 하나라도 비어있으면 예외
       if (newPassword == null || newConfirmPassword == null || newPassword.isBlank() || newConfirmPassword.isBlank()) {
         throw new DeepdiviewException(ErrorCode.EMPTY_PASSWORD);
-      }
-      if (!isValidPassword(newPassword)) {
-        throw new DeepdiviewException(ErrorCode.NOT_ENOUGH_PASSWORD);
       }
       if (!newPassword.equals(newConfirmPassword)) {
         throw new DeepdiviewException(ErrorCode.NOT_VALID_PASSWORD);
@@ -267,11 +272,6 @@ public class UserService {
 
   }
 
-  // 비밀번호 8자 이상 작성해야 유효
-  private boolean isValidPassword(String password) {
-    String regex = "\\w{8,}";
-    return Pattern.compile(regex).matcher(password).matches();
-  }
 
   /**
    * 한줄소개 설정/수정/삭제

--- a/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
@@ -62,8 +62,10 @@ public enum ErrorCode {
   NOTIFICATION_NOT_FOUND("존재하지 않는 알람입니다.", HttpStatus.NOT_FOUND),
 
   // 형변환 관련 에러코드
-  INVALID_INPUT_VALUE("입력값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+  INVALID_INPUT_VALUE("입력값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
+  // 유효성 관련 에러코드
+  VALIDATION_FAILED("입력한 값에 오류가 있습니다.", HttpStatus.BAD_REQUEST);
   private final String description;
   private final HttpStatus httpStatus;
 }

--- a/ddv/src/main/java/community/ddv/global/exception/ErrorResponse.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorResponse.java
@@ -1,5 +1,6 @@
 package community.ddv.global.exception;
 
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,5 +10,12 @@ public class ErrorResponse {
 
   private final String errorCode;    // 에러 코드
   private final String errorMessage; // 에러 메시지
+  private final Map<String, String> validErrors; // 유효성 검사 오류
 
+  // 유효성 검사 에러 없는 기본 생성자
+  public ErrorResponse(String errorCode, String errorMessage) {
+    this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
+    this.validErrors = null;
+  }
 }


### PR DESCRIPTION
# [변경사항]

1.유효성 검사 예외 메시지를 커스텀 예외 응답 내부에 포함하도록 수정했습니다 
> 예시 

> {
>   "errorCode": "VALIDATION_FAILED",
>   "errorMessage": "입력한 값에 오류가 있습니다.",
>     "validErrors": {
>       "newPassword": "영문 소문자와 숫자를 포함하여 8자 이상이어야 합니다.",
>       "newConfirmPassword": "비밀번호를 확인해주세요"
>     }
> }

2. 닉네임 수정과 비밀번호 수정 API를 분리했습니다. 
    - /api/users/me/nickname
    - /api/users/me/password
    
3. 비밀번호는 영소문자, 숫자 포함 8자 이상 적도록 유효성 검사를 추가했습니다.  