### PR TITLE
Feature/develop

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
@@ -3,6 +3,7 @@ package community.ddv.domain.board.controller;
 import community.ddv.domain.board.dto.CommentDTO.CommentResponseDto;
 import community.ddv.domain.board.service.CommentService;
 import community.ddv.domain.board.dto.CommentDTO;
+import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -67,11 +68,11 @@ public class CommentController {
 
   @Operation(summary = "특정 리뷰에 달린 댓글 조회")
   @GetMapping
-  public ResponseEntity<Page<CommentResponseDto>> getCommentsByReviewId(
+  public ResponseEntity<PageResponse<CommentResponseDto>> getCommentsByReviewId(
       @PathVariable Long reviewId,
       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
     Page<CommentResponseDto> comments = commentService.getCommentsByReviewId(reviewId, pageable);
-    return ResponseEntity.ok(comments);
+    return ResponseEntity.ok(new PageResponse<>(comments));
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
@@ -4,6 +4,7 @@ import community.ddv.domain.board.dto.ReviewDTO;
 import community.ddv.domain.board.dto.ReviewResponseDTO;
 import community.ddv.domain.board.service.LikeService;
 import community.ddv.domain.board.service.ReviewService;
+import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -65,7 +66,7 @@ public class ReviewController {
 
   @Operation(summary = "특정 영화에 대한 리뷰 조회", description = "댓글은 포함되어있지 않습니다. ?sortBy=likeCount로 좋아요 순 정렬을 할 수 있습니다." )
   @GetMapping("/movie/{tmdbId}")
-  public ResponseEntity<Page<ReviewResponseDTO>> getReviewsByMovieId(
+  public ResponseEntity<PageResponse<ReviewResponseDTO>> getReviewsByMovieId(
       @PathVariable Long tmdbId,
       @RequestParam(value = "certifiedFilter", required = false, defaultValue = "false") Boolean certifiedFilter,
       @PageableDefault(size = 20) Pageable pageable,
@@ -81,7 +82,7 @@ public class ReviewController {
 
     Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
     Page<ReviewResponseDTO> reviews = reviewService.getReviewByMovieId(tmdbId, sortedPageable, certifiedFilter);
-    return ResponseEntity.ok(reviews);
+    return ResponseEntity.ok(new PageResponse<>(reviews));
   }
 
   @Operation(summary = "특정 리뷰 조회", description = "댓글이 포함되어 있습니다.")

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationController.java
@@ -3,6 +3,7 @@ package community.ddv.domain.certification;
 import community.ddv.domain.certification.CertificationDTO.CertificationRequestDto;
 import community.ddv.domain.certification.CertificationDTO.CertificationResponseDto;
 import community.ddv.domain.certification.constant.CertificationStatus;
+import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
@@ -62,12 +63,12 @@ public class CertificationController {
 
   @Operation(summary = "인증 목록 조회", description = "관리자 전용 - 보류, 승인, 거절 필터링 가능 | 한 페이지당 10개씩 반환 ㅣ 인증요청을 한 지 오래된 순서대로 정렬됩니다.")
   @GetMapping("/admin")
-  public ResponseEntity<Page<CertificationResponseDto>> getPendingCertifications(
+  public ResponseEntity<PageResponse<CertificationResponseDto>> getPendingCertifications(
       @RequestParam(required = false) CertificationStatus status,
       @PageableDefault(size = 10, page = 0, sort = "createdAt", direction = Direction.ASC) Pageable pageable) {
     Page<CertificationResponseDto> certifications =
         certificationService.getCertificationsByStatus(status, pageable);
-    return ResponseEntity.ok(certifications);
+    return ResponseEntity.ok(new PageResponse<>(certifications));
   }
 
 

--- a/ddv/src/main/java/community/ddv/domain/movie/controller/MovieController.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/controller/MovieController.java
@@ -2,6 +2,7 @@ package community.ddv.domain.movie.controller;
 
 import community.ddv.domain.movie.dto.MovieDTO;
 import community.ddv.domain.movie.service.MovieService;
+import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -35,13 +36,13 @@ public class MovieController {
 
   @Operation(summary = "영화 제목으로 상세정보 조회", description = "특정 단어가 포함되어 있는 영화들의 세부정보를 반환합니다. 띄어쓰기를 무시하고도 조회가 됩니다.")
   @GetMapping("/search/list")
-  public ResponseEntity<Page<MovieDTO>> getMoviesByTitle(
+  public ResponseEntity<PageResponse<MovieDTO>> getMoviesByTitle(
       @RequestParam("title") String title,
       @RequestParam(value = "certifiedFilter", required = false, defaultValue = "false") Boolean certifiedFilter,
       @PageableDefault(size = 10, sort = "popularity", direction = Sort.Direction.DESC) Pageable pageable
       ) {
     Page<MovieDTO> movies = movieService.searchMoviesByTitle(title, certifiedFilter, pageable);
-    return ResponseEntity.ok(movies);
+    return ResponseEntity.ok(new PageResponse<>(movies));
   }
 
   @Operation(summary = "특정 영화 상세정보 조회", description = "tmdb에서 제공하는 id값(tmdbId)을 넣어야 조회됩니다.")

--- a/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
+++ b/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
@@ -5,7 +5,9 @@ import community.ddv.domain.board.dto.ReviewResponseDTO;
 import community.ddv.domain.user.dto.LoginResponse;
 import community.ddv.domain.user.dto.UserDTO;
 import community.ddv.domain.user.dto.UserDTO.AccountDeleteDto;
-import community.ddv.domain.user.dto.UserDTO.OneLineIntro;
+import community.ddv.domain.user.dto.UserDTO.NicknameUpdateResponseDto;
+import community.ddv.domain.user.dto.UserDTO.OneLineIntroRequestDto;
+import community.ddv.domain.user.dto.UserDTO.OneLineIntroResponseDto;
 import community.ddv.domain.user.dto.UserDTO.TokenDto;
 import community.ddv.domain.user.dto.UserDTO.UserInfoResponseDto;
 import community.ddv.domain.user.service.ProfileImageService;
@@ -23,7 +25,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -95,11 +96,10 @@ public class UserController {
   // 닉네임 수정 API
   @Operation(summary = "닉네임 수정")
   @PutMapping("/me/nickname")
-  public ResponseEntity<Void> updateAccount(
-      @RequestBody @Valid UserDTO.NicknameUpdateDto nicknameUpdateDto
+  public ResponseEntity<NicknameUpdateResponseDto> updateAccount(
+      @RequestBody @Valid UserDTO.NicknameUpdateRequestDto nicknameUpdateDto
   ) {
-    userService.updateNickname(nicknameUpdateDto);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok(userService.updateNickname(nicknameUpdateDto));
   }
 
   // 비밀번호 수정 API
@@ -114,11 +114,10 @@ public class UserController {
 
   @Operation(summary = "한줄소개 설정/수정", description = "회원가입 직후에는 새롭게 설정, 설정된 이후에는 수정")
   @PutMapping("/me/intro")
-  public ResponseEntity<Void> updateIntro(
-      @RequestBody OneLineIntro oneLineIntro
+  public ResponseEntity<OneLineIntroResponseDto> updateIntro(
+      @RequestBody OneLineIntroRequestDto oneLineIntro
   ) {
-    userService.updateOneLineIntro(oneLineIntro);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok(userService.updateOneLineIntro(oneLineIntro));
   }
 
   @Operation(summary = "내 정보 확인", description = "닉네임, 이메일, 프로필사진, 한줄소개, 리뷰수, 댓글수, 별점 분포")
@@ -175,9 +174,10 @@ public class UserController {
 
   @Operation(summary = "프로필사진 삭제")
   @DeleteMapping("/profile-image")
-  public ResponseEntity<Void> deleteProfileImage() {
-    profileImageService.deleteProfileImage();
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<Map<String, String>> deleteProfileImage() {
+    Map<String, String> DefaultProfileResponse = new HashMap<>();
+    DefaultProfileResponse.put("profileImageUrl", profileImageService.deleteProfileImage());
+    return ResponseEntity.ok(DefaultProfileResponse);
   }
 
 }

--- a/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
+++ b/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
@@ -152,17 +152,8 @@ public class UserController {
     return ResponseEntity.ok(new PageResponse<>(reviews));
   }
 
-  @Operation(summary = "프로필사진 등록")
-  @PostMapping("/profile-image")
-  public ResponseEntity<Map<String, String>> uploadProfileImage(
-      @RequestParam("file") MultipartFile file) {
-    String profileImageUrl = profileImageService.uploadProfileImage(file);
-    Map<String, String> profileResponse = new HashMap<>();
-    profileResponse.put("profileImageUrl", profileImageUrl);
-    return ResponseEntity.ok(profileResponse);
-  }
 
-  @Operation(summary = "프로필사진 수정")
+  @Operation(summary = "프로필사진 등록/수정")
   @PutMapping("/profile-image")
   public ResponseEntity<Map<String, String>> updateProfileImage(
       @RequestParam("file") MultipartFile file) {

--- a/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
+++ b/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import community.ddv.domain.user.service.ProfileImageService;
 import community.ddv.domain.user.service.UserService;
 import community.ddv.domain.board.service.CommentService;
 import community.ddv.domain.board.service.ReviewService;
+import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -134,21 +136,21 @@ public class UserController {
 
   @Operation(summary = "특정 사용자가 작성한 댓글 조회")
   @GetMapping("/{userId}/comments")
-  public ResponseEntity<Page<CommentResponseDto>> getCommentsByUserId(
+  public ResponseEntity<PageResponse<CommentResponseDto>> getCommentsByUserId(
       @PathVariable Long userId,
       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
     Page<CommentResponseDto> comments = commentService.getCommentsByUserId(userId, pageable);
-    return ResponseEntity.ok(comments);
+    return ResponseEntity.ok(new PageResponse<>(comments));
   }
 
   @Operation(summary = "특정 사용자가 작성한 리뷰 조회")
   @GetMapping("{userId}/reviews")
-  public ResponseEntity<Page<ReviewResponseDTO>> getReviewsByUserId(
+  public ResponseEntity<PageResponse<ReviewResponseDTO>> getReviewsByUserId(
       @PathVariable Long userId,
       @RequestParam(value = "certifiedFilter", required = false, defaultValue = "false") Boolean certifiedFilter,
       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
     Page<ReviewResponseDTO> reviews = reviewService.getReviewsByUserId(userId, pageable, certifiedFilter);
-    return ResponseEntity.ok(reviews);
+    return ResponseEntity.ok(new PageResponse<>(reviews));
   }
 
   @Operation(summary = "프로필사진 등록")

--- a/ddv/src/main/java/community/ddv/domain/user/dto/UserDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/user/dto/UserDTO.java
@@ -5,7 +5,6 @@ import community.ddv.domain.certification.constant.RejectionReason;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -54,10 +53,15 @@ public class UserDTO {
   }
 
   @Getter
-  public static class NicknameUpdateDto {
+  public static class NicknameUpdateRequestDto {
     @NotBlank(message = "새로운 닉네임을 입력해주세요")
     private String newNickname;
+  }
 
+  @Getter
+  @AllArgsConstructor
+  public static class NicknameUpdateResponseDto {
+    private String updatedNickname;
   }
 
   @Getter
@@ -74,8 +78,14 @@ public class UserDTO {
   }
 
   @Getter
-  public static class OneLineIntro {
+  public static class OneLineIntroRequestDto {
     private String oneLineIntro;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class OneLineIntroResponseDto {
+    private String updatedOneLineIntro;
   }
 
   @Getter

--- a/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
@@ -61,7 +61,7 @@ public class ProfileImageService {
    * 프로필 사진 삭제
    */
   @Transactional
-  public void deleteProfileImage() {
+  public String deleteProfileImage() {
     User user = userService.getLoginUser();
     log.info("프로필사진 삭제 요청");
 
@@ -73,5 +73,6 @@ public class ProfileImageService {
     }
     user.updateProfileImageUrl(defaultProfileImageUrl);
     log.info("기본 프로필로 초기화");
+    return defaultProfileImageUrl;
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
@@ -20,41 +20,28 @@ public class ProfileImageService {
   private final UserService userService;
   private final FileStorageService fileStorageService;
 
-  /**
-   * 프로필 등록
-   */
-  @Transactional
-  public String uploadProfileImage(MultipartFile profileImage) {
-    User user = userService.getLoginUser();
-    log.info("프로필 사진 등록 요청");
 
-    String profileImageUrl = fileStorageService.uploadFile(profileImage);
-
-    user.updateProfileImageUrl(profileImageUrl);
-    return profileImageUrl;
-  }
-
-  /**
-   * 프로필 수정
-   *
-   * @param profileImage
-   */
   @Transactional
   public String updateProfileImage(MultipartFile profileImage) {
-    User user = userService.getLoginUser();
-    log.info("프로필사진 수정 요청");
 
-    // 기존 프로필 삭제
-    if (user.getProfileImageUrl() != null) {
-      fileStorageService.deleteFile(user.getProfileImageUrl());
-      log.info("기존 프로필 사진 삭제");
+    User user = userService.getLoginUser();
+    String existingProfileImageUrl = user.getProfileImageUrl();
+
+    // 기존 프사가 존재하는 경우, 삭제 후 새 이미지로 대체 (디폴트 프사가 아닐 때!)
+    if (existingProfileImageUrl != null && !existingProfileImageUrl.isEmpty()
+    && !isDefaultProfileImage(existingProfileImageUrl)) {
+      fileStorageService.deleteFile(existingProfileImageUrl);
     }
 
     String newProfileImageUrl = fileStorageService.uploadFile(profileImage);
     user.updateProfileImageUrl(newProfileImageUrl);
-    log.info("프로필 이미지 수정");
-
+    log.info("프로필 이미지 등록/수정 완료");
     return newProfileImageUrl;
+
+  }
+
+  private boolean isDefaultProfileImage(String imageUrl) {
+    return imageUrl.contains(defaultProfileImageUrl);
   }
 
   /**
@@ -65,11 +52,11 @@ public class ProfileImageService {
     User user = userService.getLoginUser();
     log.info("프로필사진 삭제 요청");
 
-    if (user.getProfileImageUrl() != null && !user.getProfileImageUrl().isEmpty()
-        && !user.getProfileImageUrl().equals(defaultProfileImageUrl)) {
+    String profileImageUrl = user.getProfileImageUrl();
+    if (profileImageUrl != null && !profileImageUrl.isEmpty()
+        && !profileImageUrl.equals(defaultProfileImageUrl)) {
 
       fileStorageService.deleteFile(user.getProfileImageUrl());
-      log.info("기존 프로필 사진 삭제");
     }
     user.updateProfileImageUrl(defaultProfileImageUrl);
     log.info("기본 프로필로 초기화");

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -8,9 +8,11 @@ import community.ddv.domain.certification.CertificationRepository;
 import community.ddv.domain.certification.constant.RejectionReason;
 import community.ddv.domain.user.dto.LoginResponse;
 import community.ddv.domain.user.dto.UserDTO.AccountDeleteDto;
-import community.ddv.domain.user.dto.UserDTO.NicknameUpdateDto;
+import community.ddv.domain.user.dto.UserDTO.NicknameUpdateRequestDto;
 import community.ddv.domain.user.dto.UserDTO.LoginDto;
-import community.ddv.domain.user.dto.UserDTO.OneLineIntro;
+import community.ddv.domain.user.dto.UserDTO.NicknameUpdateResponseDto;
+import community.ddv.domain.user.dto.UserDTO.OneLineIntroRequestDto;
+import community.ddv.domain.user.dto.UserDTO.OneLineIntroResponseDto;
 import community.ddv.domain.user.dto.UserDTO.PasswordUpdateDto;
 import community.ddv.domain.user.dto.UserDTO.SignUpDto;
 import community.ddv.domain.user.dto.UserDTO.TokenDto;
@@ -28,7 +30,6 @@ import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -228,24 +229,23 @@ public class UserService {
    * 닉네임 수정
    */
   @Transactional
-  public void updateNickname(NicknameUpdateDto nicknameUpdateDto) {
+  public NicknameUpdateResponseDto updateNickname(NicknameUpdateRequestDto nicknameUpdateDto) {
 
     User user = getLoginUser();
     log.info("닉네임 수정시도 : {}", user.getEmail());
 
     String newNickname = nicknameUpdateDto.getNewNickname();
 
-    // 닉네임 변경 시도
-    if (newNickname != null && !newNickname.isBlank()) {
-      log.info("닉네임 변경시도 {} -> {}", user.getNickname(), newNickname);
-
-      // 이미 존재하는 닉네임으로는 변경 불가 (자신이 예전에 쓰던 닉네임 포함)
-      if (userRepository.findByNickname(newNickname).isPresent()) {
-        log.info("이미 존재하는 닉네임이 있어 해당 닉네임으로 변경 불가");
-        throw new DeepdiviewException(ErrorCode.ALREADY_EXIST_NICKNAME);
-      }
-      user.updateNickname(newNickname);
+    if (newNickname.equals(user.getNickname())) {
+      return new NicknameUpdateResponseDto(user.getNickname());
     }
+
+    if (userRepository.findByNickname(newNickname).isPresent()) {
+      throw new DeepdiviewException(ErrorCode.ALREADY_EXIST_NICKNAME);
+    }
+
+    user.updateNickname(newNickname);
+    return new NicknameUpdateResponseDto(newNickname);
   }
 
   @Transactional
@@ -278,7 +278,7 @@ public class UserService {
    * @param oneLineIntro
    */
   @Transactional
-  public void updateOneLineIntro(OneLineIntro oneLineIntro) {
+  public OneLineIntroResponseDto updateOneLineIntro(OneLineIntroRequestDto oneLineIntro) {
 
     User user = getLoginUser();
     log.info("한줄소개 수정 시도 : {}", user.getEmail());
@@ -302,6 +302,7 @@ public class UserService {
       }
     }
     userRepository.save(user);
+    return new OneLineIntroResponseDto(newOneLineIntro);
   }
 
 

--- a/ddv/src/main/java/community/ddv/global/response/PageResponse.java
+++ b/ddv/src/main/java/community/ddv/global/response/PageResponse.java
@@ -1,0 +1,33 @@
+package community.ddv.global.response;
+
+import community.ddv.domain.board.dto.ReviewResponseDTO;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@AllArgsConstructor
+@Getter
+public class PageResponse<T> {
+  private List<T> content;
+  private int number; // 현재 페이지 번호 (0부터)
+  private int size; // 페이지 당 아이템 수
+  private int totalPages; // 전체 페이지 수
+  private long totalElements; // 전체 아이템 수
+  private int numberOfElements; // 현재 페이지 내의 아이템 수
+  private boolean first; // 첫 페이지 여부
+  private boolean last; // 마지막 페이지 여부
+  private boolean empty; // 현재 페이지가 비어있는지 여부
+
+  public PageResponse(Page<T> page) {
+    this.content = page.getContent();
+    this.number = page.getNumber();
+    this.size = page.getSize();
+    this.totalPages = page.getTotalPages();
+    this.totalElements = page.getTotalElements();
+    this.numberOfElements = page.getNumberOfElements();
+    this.first = page.isFirst();
+    this.last = page.isLast();
+    this.empty = page.isEmpty();
+  }
+}


### PR DESCRIPTION
# [변경사항]

## 1. PageImpl 경고 해결 및 커스텀 PageResponseDTO 적용
- 기존에 발생하던 메시지 
> ration$PageModule$WarningLoggingModifier : Serializing PageImpl instances as-is is not supported, 
meaning that there is no guarantee about the stability of the resulting JSON structure!
> For a stable JSON structure, please use Spring Data's PagedModel (globally via @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)) or Spring HATEOAS and Spring Data's PagedResourcesAssembler

- 이를 해결하기 위해 PagedModel 타입으로 수정하려 했으나, 아래와 같이 고정된 구조만 제공하여 원하는 응답 데이터를 보낼 수 없다는 어려움이 있었습니다. 

> {
  "content": [],
  "page": {
    "size": 10,
    "number": 1,
    "totalElements": 10,
    "totalPages": 10
  }
}

- 따라서 PageResponse<T> DTO 를 커스텀하여 적용하였습니다. 

-----

## 2.닉네임/ 한줄소개/프사 변경/삭제 시, 응답값 추가
- 기존 204 No Content-> 200 OK로 변경하고, 수정된 겂울 응답 바디에 넣어 반환하도록 수정했습니다. 
  
-----    
    
## 3. 프로필 등록, 수정을 하나의 서비스 코드로 병합
- 등록과 수정 코드의 로직과 예외 처리가 유사하여 하나의 서비스 메서드로 병합했습니다..
- 최초 등록시, 디폴트 프사가 S3에서 삭제되지 않도록 수정했습니다. 
