### PR TITLE
Feat : 인증샷이 존재하지 않는 경우 404 대신 200 반환하는 것으로 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationRepository.java
@@ -14,7 +14,9 @@ import org.springframework.stereotype.Repository;
 public interface CertificationRepository extends JpaRepository<Certification, Long> {
 
   boolean existsByUser_IdAndStatus(Long userId, CertificationStatus status);
+
   Page<Certification> findByStatus(CertificationStatus status, Pageable pageable);
+  Page<Certification> findByStatusIsNotNull(Pageable pageable);
 
   // ENUM 타입을 NULL로 초기화 하기 위해 네이티브쿼리 사용
   @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -24,5 +26,4 @@ public interface CertificationRepository extends JpaRepository<Certification, Lo
   Optional<Certification> findTopByUser_IdOrderByCreatedAtDesc(Long userId);
   Optional<Certification> findTopByUser_IdAndCreatedAtBetweenOrderByCreatedAtDesc(Long userId, LocalDateTime start, LocalDateTime end);
 
-  Page<Certification> findByStatusIsNotNull(Pageable pageable);
 }

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -82,7 +82,18 @@ public class CertificationService {
 
     // 사용자가 제출한 인증샷 조회
     Certification certification = certificationRepository.findTopByUser_IdOrderByCreatedAtDesc(user.getId())
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND));
+        .orElse(null);
+
+    if (certification == null) {
+      return CertificationResponseDto.builder()
+          .id(null)
+          .userId(null)
+          .certificationUrl(null)
+          .status(CertificationStatus.NONE)
+          .createdAt(null)
+          .rejectionReason(null)
+          .build();
+    }
 
     // PENDING 또는 REJECTED 상태에서만 반환
     CertificationStatus status = certification.getStatus();

--- a/ddv/src/main/java/community/ddv/domain/certification/constant/CertificationStatus.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/constant/CertificationStatus.java
@@ -4,6 +4,7 @@ public enum CertificationStatus {
 
   PENDING, // 보류
   APPROVED, // 승인
-  REJECTED // 거절
+  REJECTED, // 거절
+  NONE // 미제출
 
 }


### PR DESCRIPTION
# [변경사항]

- 인증샷을 제출하지 않은 상태에서 인증샷 상태조회 API(`/api/certifications/me`) 호출시 
  - 수정 전 : 404 에러 반환 
  - 수정 후 : 200 OK 응답과 함께 status에 NONE을 추가하여 반환하고, 다른 값들은 null로 반환하도록 수정 

## 변경 이유
- 인증샷은 사용자에 따라 없을 수도 있는 리소스이기 때문에, 에러 페이지로 이동하는 대신
 정상 응답으로 처리하고 업로드 폼을 보여줄 수 있도록 하기 위함