### PR TITLE
fix : 알림 목록 조회 시 페이징처리 추가, 자신의 인증샷 내역 조회시 이번주의 인증샷 내역만 조회되도록 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
@@ -1,10 +1,14 @@
 package community.ddv.domain.notification;
 
 import community.ddv.domain.notification.dto.NotificationResponseDTO;
+import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,8 +37,9 @@ public class NotificationController {
 
   @Operation(summary = "알림 목록 조회")
   @GetMapping
-  public ResponseEntity<List<NotificationResponseDTO>> getNotifications() {
-    List<NotificationResponseDTO> notifications = notificationService.getNotifications();
+  public ResponseEntity<PageResponse<NotificationResponseDTO>> getNotifications(
+      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    PageResponse<NotificationResponseDTO> notifications = notificationService.getNotifications(pageable);
     return ResponseEntity.ok(notifications);
   }
 

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationRepository.java
@@ -2,6 +2,8 @@ package community.ddv.domain.notification;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
   Optional<Notification> findByIdAndUser_Id(Long notificationId, Long userId);
-  List<Notification> findByUser_IdOrderByCreatedAtDesc(Long userId);
+  Page<Notification> findByUser_IdOrderByCreatedAtDesc(Long userId, Pageable pageable);
   List<Notification> findByUser_IdAndIsReadFalseOrderByCreatedAtDesc(Long userId);
 
 }

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -11,6 +11,7 @@ import community.ddv.global.exception.DeepdiviewException;
 import community.ddv.domain.certification.CertificationRepository;
 import community.ddv.domain.board.repository.ReviewRepository;
 import community.ddv.domain.user.service.UserService;
+import community.ddv.global.response.PageResponse;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,6 +20,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -251,14 +254,13 @@ public class NotificationService {
   }
 
   // 알림 목록 조회
-  public List<NotificationResponseDTO> getNotifications() {
+  public PageResponse<NotificationResponseDTO> getNotifications(Pageable pageable) {
     log.info("알림 목록 조회 요청");
     User user = userService.getLoginUser();
     log.info("요청자 : userId = {}", user.getId());
-    List<Notification> notifications = notificationRepository.findByUser_IdOrderByCreatedAtDesc(user.getId());
-    return notifications.stream()
-        .map(this::convertToNotificationResponseDTO)
-        .collect(Collectors.toList());
+    Page<Notification> notifications = notificationRepository.findByUser_IdOrderByCreatedAtDesc(user.getId(), pageable);
+    Page<NotificationResponseDTO> notificationResponseDTOS = notifications.map(this::convertToNotificationResponseDTO);
+    return new PageResponse<>(notificationResponseDTOS);
   }
 
   private NotificationResponseDTO convertToNotificationResponseDTO(Notification notification) {

--- a/ddv/src/main/java/community/ddv/global/response/PageResponse.java
+++ b/ddv/src/main/java/community/ddv/global/response/PageResponse.java
@@ -1,6 +1,5 @@
 package community.ddv.global.response;
 
-import community.ddv.domain.board.dto.ReviewResponseDTO;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;


### PR DESCRIPTION
# [변경사항]

1.  알림 목록 조회 시, 페이징처리를 추가했습니다. 기본은 createdAt desc 입니다. 
2. 이번주(월-토)에 인증을 한 경우에만 자신의 인증샷 url, 상태를 볼 수 있도록 수정했습니다. 
DB에 여러 개가 있어도 이번 주의 인증샷 내역만 조회합니다. 
