### PR TITLE
feat : 커서 기반으로 인증 리스트를 조회하고, 다음 커서 정보를 함께 반환하는 Cursor Pagination 구현

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationRepository.java
@@ -2,12 +2,13 @@ package community.ddv.domain.certification;
 
 import community.ddv.domain.certification.constant.CertificationStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,8 +16,31 @@ public interface CertificationRepository extends JpaRepository<Certification, Lo
 
   boolean existsByUser_IdAndStatus(Long userId, CertificationStatus status);
 
-  Page<Certification> findByStatus(CertificationStatus status, Pageable pageable);
-  Page<Certification> findByStatusIsNotNull(Pageable pageable);
+//  Page<Certification> findByStatus(CertificationStatus status, Pageable pageable);
+//  Page<Certification> findByStatusIsNotNull(Pageable pageable);
+
+  // 상태별 조회
+  @Query("SELECT c FROM Certification c WHERE " +
+      "( c.status = :status) AND " +
+      "((c.createdAt > :createdAt) OR (c.createdAt = :createdAt AND c.id > :id)) " +
+      "ORDER BY c.createdAt ASC, c.id ASC")
+  List<Certification> findByStatusWithCursor(
+      @Param("status") CertificationStatus status,
+      @Param("createdAt") LocalDateTime createdAt,
+      @Param("id") Long id,
+      Pageable pageable
+  );
+
+  // 전체 조회
+  @Query("SELECT c FROM Certification c WHERE " +
+      "(c.status IS NOT NULL) AND " +
+      "((c.createdAt > :createdAt) OR (c.createdAt = :createdAt AND c.id > :id)) " +
+      "ORDER BY c.createdAt ASC, c.id ASC")
+  List<Certification> findAllWithCursor(
+    @Param("createdAt") LocalDateTime createdAt,
+    @Param("id") Long id,
+    Pageable pageable
+  );
 
   // ENUM 타입을 NULL로 초기화 하기 위해 네이티브쿼리 사용
   @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/ddv/src/main/java/community/ddv/global/response/CursorPageResponse.java
+++ b/ddv/src/main/java/community/ddv/global/response/CursorPageResponse.java
@@ -1,0 +1,17 @@
+package community.ddv.global.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CursorPageResponse<T> {
+
+  private List<T> content; // 데이터들
+  private LocalDateTime nextCreatedAt; // 마지막 인증의 생성시간
+  private Long nextCertificationId; // 마지막 인증의 ID
+  private boolean hasNext; // 더 많은 데이터가 있는지 여부
+
+}


### PR DESCRIPTION
# [변경사항]

1. 처음 요청할 때는 createdAt을 반드시 쿼리로 넘겨야 합니다.
    - createdAt=2025-04-04T00:00:00
      - 이렇게 요청하면 해당 시간 이후에 생성된 인증 요청들이 오름차순으로 반환됩니다. 
2. 쿼리 없이는 조회가 불가능합니다.
3. 마지막에 조회한 데이터 정보 
` "nextCreatedAt": "2025-04-16T00:00:00",`
` "nextCertificationId": 20,`
이걸 응답 받으면 `hasNext = false`가 될 때까지 두 가지를 모두 쿼리 파라미터 다 넣어야 합니다.
4. 상태별 필터링은 예전처럼 가능합니다.
5. size 디폴트값은 10입니다. 
