### PR TITLE
fix : 알림 관련 SecurityConfig 설정 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -45,6 +45,11 @@ public class NotificationService {
    */
   public SseEmitter subscribe(Long userId) {
 
+    Long loginUserId = userService.getLoginUser().getId(); // 현재 로그인한 사용자
+    if (!loginUserId.equals(userId)) {
+      throw new DeepdiviewException(ErrorCode.ACCESS_DENIED);
+    }
+
     log.info("SSE 구독 시작 : userId = {}", userId);
 
     // 새로운 SSE 연결

--- a/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
       "/api/discussions/is-sunday",
       "/api/discussions/this-week-movie",
       "/api/votes/result",
-      "/api/votes/result/latest"
+      "/api/votes/result/latest",
+      "/api/notifications/subscribe"
   };
 
   @Bean

--- a/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
   USER_NOT_FOUND("존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
   INVALID_REFRESH_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST),
   UNAUTHORIZED("로그인되어 있지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
+  ACCESS_DENIED("접근 불가", HttpStatus.FORBIDDEN),
 
   // 영화 관련 에러코드
   MOVIE_NOT_FOUND("존재하지 않는 영화입니다.", HttpStatus.NOT_FOUND),


### PR DESCRIPTION
# [변경사항]

1. 새로고침을 할 때마다 Access Denied 예외가 터지는 이슈를 해결하고 있습니다. 
    - 화이트리스트에 알림 구독 api 주소를 넣고, 서비스 코드 내에서 userId가 일치하는지 검증을 하는 것을 추가하였습니다. 
