### PR TITLE
fix : SSE 연결 요청에 대해 JWT 인증 필터 적용

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
@@ -1,6 +1,7 @@
 package community.ddv.domain.notification;
 
 import community.ddv.domain.notification.dto.NotificationResponseDTO;
+import community.ddv.domain.user.service.UserService;
 import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,12 +26,13 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class NotificationController {
 
   private final NotificationService notificationService;
+  private final UserService userService;
 
   // 클라이언트가 SSE 연결 구독
   @Operation(summary = "SSE 연결 구독")
   @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter subscribe(@RequestParam Long userId) {
-
+  public SseEmitter subscribe() {
+    Long userId = userService.getLoginUser().getId();
     return notificationService.subscribe(userId);
   }
 

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
@@ -4,7 +4,6 @@ import community.ddv.domain.notification.dto.NotificationResponseDTO;
 import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -1,30 +1,27 @@
 package community.ddv.domain.notification;
 
+import community.ddv.domain.board.entity.Review;
+import community.ddv.domain.board.repository.ReviewRepository;
+import community.ddv.domain.certification.Certification;
+import community.ddv.domain.certification.CertificationRepository;
+import community.ddv.domain.certification.constant.CertificationStatus;
 import community.ddv.domain.notification.dto.NotificationDTO;
 import community.ddv.domain.notification.dto.NotificationResponseDTO;
-import community.ddv.domain.certification.constant.CertificationStatus;
-import community.ddv.global.exception.ErrorCode;
-import community.ddv.domain.certification.Certification;
-import community.ddv.domain.board.entity.Review;
 import community.ddv.domain.user.entity.User;
-import community.ddv.global.exception.DeepdiviewException;
-import community.ddv.domain.certification.CertificationRepository;
-import community.ddv.domain.board.repository.ReviewRepository;
 import community.ddv.domain.user.service.UserService;
+import community.ddv.global.exception.DeepdiviewException;
+import community.ddv.global.exception.ErrorCode;
 import community.ddv.global.response.PageResponse;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -23,6 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -43,11 +45,6 @@ public class NotificationService {
    * @param userId
    */
   public SseEmitter subscribe(Long userId) {
-
-    Long loginUserId = userService.getLoginUser().getId(); // 현재 로그인한 사용자
-    if (!loginUserId.equals(userId)) {
-      throw new DeepdiviewException(ErrorCode.ACCESS_DENIED);
-    }
 
     log.info("SSE 구독 시작 : userId = {}", userId);
 

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -45,15 +45,18 @@ public class NotificationService {
 
     log.info("SSE 구독 시작 : userId = {}", userId);
 
-    // 새로운 SSE 연결
-    SseEmitter newEmitter = new SseEmitter(30 * 60 * 1000L); // 30 * 60 초 (타임아웃 30분)
-
-    // 기존 emitter가 있으면 종료
-    SseEmitter previousEmitter = emitters.put(userId, newEmitter);
+    // 1. 기존 emitter 끊기
+    SseEmitter previousEmitter = emitters.get(userId);
     if (previousEmitter != null) {
-      log.info("기존 SSE 연결 종료 및 제거: userId = {}", userId);
+      log.info("기존 emitter 존재: userId = {}", userId);
       previousEmitter.complete();
+      emitters.remove(userId);
+      log.info("기존 emitter 제거 완료: userId = {}", userId);
     }
+
+    // 2. 새 emitter 저장
+    SseEmitter newEmitter = new SseEmitter(30 * 60 * 1000L); // 30 * 60 초 (타임아웃 30분)
+    emitters.put(userId, newEmitter);
 
     // 초기 메시지 전송
     sendFirstMessage(userId, newEmitter);
@@ -100,17 +103,16 @@ public class NotificationService {
     }
 
     emitters.forEach((userId, emitter) -> {
-      if (emitter != null) {
-        try {
-          emitter.send(SseEmitter.event()
-              .name("ping")
-              .data("keep-alive"));
-        } catch (IOException | IllegalStateException e) {
-          log.warn("Ping 전송 실패 : userId = {}, error = {}", userId, e.getMessage());
-          emitter.completeWithError(e); // 오류 발생 시 연결 종료 처리
-          emitters.remove(userId); // 연결 종료
-        }
+      try {
+        emitter.send(SseEmitter.event()
+            .name("ping")
+            .data("keep-alive"));
+      } catch (Exception e) {
+        log.warn("Ping 전송 실패 : userId = {}, error = {}", userId, e.getMessage());
+        emitter.complete(); // 오류 발생 시 연결 종료
+        emitters.remove(userId); // 연결 종료
       }
+
     });
   }
 
@@ -166,9 +168,7 @@ public class NotificationService {
 
     notificationRepository.save(notification);
 
-    NotificationDTO notificationDTO = new NotificationDTO(
-        notification.getId(),"comment", NotificationType.COMMENT_ADDED.getMessage(), reviewId
-    );
+    NotificationDTO notificationDTO = new NotificationDTO(notification.getId(), "comment", NotificationType.COMMENT_ADDED.getMessage(), reviewId);
 
     log.info("댓글이 달렸다는 알림 전송 완료 ");
     sendNotification(reviewer.getId(), notificationDTO);
@@ -243,8 +243,7 @@ public class NotificationService {
     notificationRepository.save(notification);
     log.info("인증 결과 알림 전송");
 
-    NotificationDTO notificationDTO = new NotificationDTO(
-       notification.getId(), "certification", message, certificationId);
+    NotificationDTO notificationDTO = new NotificationDTO(notification.getId(), "certification", message, certificationId);
 
     sendNotification(user.getId(), notificationDTO);
   }
@@ -268,14 +267,14 @@ public class NotificationService {
         .build();
   }
 
-   /**
+  /**
    * 특정 알림 읽음 처리
    * @param notificationId
    */
   public void markNotificationAsRead(Long notificationId) {
     User user = userService.getLoginUser();
     log.info("알림 읽음 시도 : userId = {}", user.getId());
-    Notification notification = notificationRepository.findByIdAndUser_Id(notificationId, user.getId())
+    Notification notification = notificationRepository.findByIdAndUser_Id(notificationId,user.getId())
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
     if (!notification.isRead()) {
@@ -299,9 +298,9 @@ public class NotificationService {
       return;
     }
 
-      notifications.forEach(Notification::markAsRead);
-      notificationRepository.saveAll(notifications);
-      log.info("전체 알림 읽음 처리 완료");
+    notifications.forEach(Notification::markAsRead);
+    notificationRepository.saveAll(notifications);
+    log.info("전체 알림 읽음 처리 완료");
   }
 
 }

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserDetailsImpl.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserDetailsImpl.java
@@ -1,0 +1,38 @@
+package community.ddv.domain.user.service;
+
+import community.ddv.domain.user.entity.User;
+import java.util.Collection;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class UserDetailsImpl implements UserDetails {
+
+  private final Long id;
+  private final String email;
+  private final String password;
+
+  public UserDetailsImpl(User user) {
+    this.id = user.getId();
+    this.email = user.getEmail();
+    this.password = user.getPassword();
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of();
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public String getUsername() {
+    return email;
+  }
+
+}

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserDetailsServiceImpl.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserDetailsServiceImpl.java
@@ -18,7 +18,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
   @Override
   public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
     User user = userRepository.findByEmail(email)
-//        .orElseThrow(() -> new DeepdiviewException(ErrorCode.USER_NOT_FOUND));
         .orElseThrow(() -> new UsernameNotFoundException("User not found"));
     return new org.springframework.security.core.userdetails.User(
         user.getEmail(),

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserDetailsServiceImpl.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserDetailsServiceImpl.java
@@ -19,9 +19,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
   public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
     User user = userRepository.findByEmail(email)
         .orElseThrow(() -> new UsernameNotFoundException("User not found"));
-    return new org.springframework.security.core.userdetails.User(
-        user.getEmail(),
-        user.getPassword(),
-        Collections.emptyList());
+    return new UserDetailsImpl(user);
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -403,7 +403,6 @@ public class UserService {
   }
 
   // 로그인 여부 확인 메서드
-  @Transactional(readOnly = true)
   public User getLoginUser() {
 
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -403,6 +403,7 @@ public class UserService {
   }
 
   // 로그인 여부 확인 메서드
+  @Transactional(readOnly = true)
   public User getLoginUser() {
 
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/ddv/src/main/java/community/ddv/global/component/SseAuthenticationFilter.java
+++ b/ddv/src/main/java/community/ddv/global/component/SseAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package community.ddv.global.component;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@AllArgsConstructor
+public class SseAuthenticationFilter extends OncePerRequestFilter {
+  private final JwtProvider jwtProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    String acceptHeader = request.getHeader(HttpHeaders.ACCEPT);
+
+    if (acceptHeader != null && acceptHeader.contains("text/event-stream")) {
+
+      String token = extractTokenForSse(request);
+
+      if (token == null || !jwtProvider.validateToken(token)) {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        return;
+      }
+
+      Authentication authentication = jwtProvider.getAuthentication(token);
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private String extractTokenForSse(HttpServletRequest request) {
+    String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7); // "Bearer " 이후 토큰 부분만 추출
+    }
+    return null;
+  }
+}

--- a/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
@@ -43,8 +43,7 @@ public class SecurityConfig {
       "/api/discussions/is-sunday",
       "/api/discussions/this-week-movie",
       "/api/votes/result",
-      "/api/votes/result/latest",
-      "/api/notifications/subscribe"
+      "/api/votes/result/latest"
   };
 
   @Bean

--- a/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package community.ddv.global.config;
 
 import community.ddv.global.component.JwtAuthenticationEntryPoint;
 import community.ddv.global.component.JwtFilter;
+import community.ddv.global.component.SseAuthenticationFilter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -43,11 +44,16 @@ public class SecurityConfig {
       "/api/discussions/is-sunday",
       "/api/discussions/this-week-movie",
       "/api/votes/result",
-      "/api/votes/result/latest"
+      "/api/votes/result/latest",
+      "/api/notifications/subscribe"
   };
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity, JwtFilter jwtFilter, JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint)
+  public SecurityFilterChain securityFilterChain(
+      HttpSecurity httpSecurity,
+      JwtFilter jwtFilter,
+      JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
+      SseAuthenticationFilter sseAuthenticationFilter)
       throws Exception {
 
     return httpSecurity
@@ -66,6 +72,7 @@ public class SecurityConfig {
         .exceptionHandling(exception ->
             exception.authenticationEntryPoint(jwtAuthenticationEntryPoint)) // 401 처리
         .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterAfter(sseAuthenticationFilter, JwtFilter.class) // SSE 인증 필터
         .build();
   }
 

--- a/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
@@ -17,7 +17,6 @@ public enum ErrorCode {
   USER_NOT_FOUND("존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
   INVALID_REFRESH_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST),
   UNAUTHORIZED("로그인되어 있지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
-  ACCESS_DENIED("접근 불가", HttpStatus.FORBIDDEN),
 
   // 영화 관련 에러코드
   MOVIE_NOT_FOUND("존재하지 않는 영화입니다.", HttpStatus.NOT_FOUND),


### PR DESCRIPTION
# [변경사항]

- /api/notifications/subscribe를 permitAll()로 열어주되, SseAuthenticationFilter 안에서 JWT를 직접 검증해 SecurityContext를 채워 인증 흐름을 안전하게 유지하도록 수정했습니다.