### PR TITLE
fix : 기존에 존재하던 emitter를 complete() 해버려서 ping이 오지 않던 이슈 해결

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -46,12 +46,10 @@ public class NotificationService {
     log.info("SSE 구독 시작 : userId = {}", userId);
 
     // 1. 기존 emitter 끊기
-    SseEmitter previousEmitter = emitters.get(userId);
+    SseEmitter previousEmitter = emitters.remove(userId);
+
     if (previousEmitter != null) {
-      log.info("기존 emitter 존재: userId = {}", userId);
-      previousEmitter.complete();
-      emitters.remove(userId);
-      log.info("기존 emitter 제거 완료: userId = {}", userId);
+      log.info("기존 emitter 존재 -> 제거 완료 userId = {}", userId);
     }
 
     // 2. 새 emitter 저장


### PR DESCRIPTION


# [변경사항]

- 기존에 존재하던 emitter가 있는 경우, 
previousEmitter.complete();로 인해 연결 스트림 자체가 닫혀버려서 
emitter가 종료되고 ping이 오지 않는 이슈가 있었습니다. 

  - previousEmitter.complete();는 삭제하고, emitters.remove(userId)로 Map에서만 제거하도록 수정했습니다.
