### PR TITLE
refactor : JWT 토큰 생성, 유효성 검사 메서드 리팩토링 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -114,7 +114,7 @@ public class UserService {
 
     String refreshToken = redisRefreshTokenTemplate.opsForValue().get(user.getEmail());
     // 리프레시 토큰 생성 (없거나 만료되었으면 새로 생성)
-    if (refreshToken == null || jwtProvider.isTokenExpired(refreshToken)) {
+    if (refreshToken == null || !jwtProvider.isTokenValid(refreshToken)) {
       refreshToken = generateAndStoreRefreshToken(user);
     } else {
       log.info("유효한 리프레시 토큰 사용");
@@ -173,7 +173,7 @@ public class UserService {
     log.info("리프레시 토큰으로 엑세스 토큰 재발급 요청");
 
     // 리프레시 토큰이 유효한지 확인
-    if (jwtProvider.isTokenExpired(refreshToken)) {
+    if (!jwtProvider.isTokenValid(refreshToken)) {
       throw new DeepdiviewException(ErrorCode.INVALID_REFRESH_TOKEN);
     }
 

--- a/ddv/src/main/java/community/ddv/global/component/JwtFilter.java
+++ b/ddv/src/main/java/community/ddv/global/component/JwtFilter.java
@@ -38,17 +38,17 @@ public class JwtFilter extends OncePerRequestFilter {
 
     String token = extractToken(request);
     try {
-      if (token != null) {
+      if (token != null && jwtProvider.validateToken(token)) {
         String email = jwtProvider.extractEmail(token);
-        jwtProvider.validateToken(token, email);
         Role role = jwtProvider.getRoleFromToken(token);
+
         UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
-            Collections.singletonList(new SimpleGrantedAuthority(role.name())));
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+            userDetails, null, Collections.singletonList(new SimpleGrantedAuthority(role.name())));
         SecurityContextHolder.getContext().setAuthentication(authentication);
       }
-
       filterChain.doFilter(request, response);
+
     } catch (ExpiredJwtException e) {
       log.warn("만료된 JWT 토큰: {}", e.getMessage());
       setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "토큰이 만료되었습니다.");

--- a/ddv/src/main/java/community/ddv/global/component/JwtProvider.java
+++ b/ddv/src/main/java/community/ddv/global/component/JwtProvider.java
@@ -43,35 +43,27 @@ public class JwtProvider {
   }
 
 
-  // 엑세스 토큰 생성
-  public String generateAccessToken(String email, Role role) {
-
+  // 토큰 생성 메서드
+  public String generateToken(String email, Role role, long expirationTime) {
     return Jwts.builder()
         .subject(email)
         .claim("role", role.name())
         .issuedAt(new Date()) // 토큰 발행시간
-        .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRED_TIME)) // 만료시간
+        .expiration(new Date(System.currentTimeMillis() + expirationTime)) // 만료시간
         .signWith(key)
         .compact();
   }
 
-  public Role getRoleFromToken(String token) {
+  // 엑세스 토큰 생성
+  public String generateAccessToken(String email, Role role) {
 
-    Claims claims = extractClaims(token);
-    return Role.valueOf(claims.get("role", String.class));
+    return generateToken(email, role, ACCESS_TOKEN_EXPIRED_TIME);
   }
-
 
   // 리프레시 토큰 생성
   public String generateRefreshToken(String email, Role role) {
 
-    return Jwts.builder()
-        .subject(email)
-        .claim("role", role.name())
-        .issuedAt(new Date()) // 토큰 발행시간
-        .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRED_TIME)) // 만료시간
-        .signWith(key)
-        .compact();
+    return generateToken(email, role, REFRESH_TOKEN_EXPIRED_TIME);
   }
 
 
@@ -86,6 +78,13 @@ public class JwtProvider {
   // 토큰에서 이메일 추출
   public String extractEmail(String token) {
     return extractClaims(token).getSubject();
+  }
+
+  // 토큰에서 역할 추출
+  public Role getRoleFromToken(String token) {
+
+    Claims claims = extractClaims(token);
+    return Role.valueOf(claims.get("role", String.class));
   }
 
   // 토큰 파싱해서 Authentication 객체 반환


### PR DESCRIPTION
# [변경사항]

1. 엑세스, 리프레시 토큰 메서드의 중복을 없애기 위해 토큰 생성 메서드를 통합했습니다.
2. Authentication 객체 반환시, UsernamePasswordAuthenticationToken 두 번째 인자에 토큰 대신 null을 넣는 것으로 수정했습니다. 
3. validateToken()에서 email없이  token만 받는 것으로 통일했습니다.
4.  로그인, 토큰재발급 시 사용되는 토큰 유효성 여부 확인 후 T/F 반환하는 메서드를 리팩토링했습니다. 
    - isTokenExpired(String token) -> isTokenValid(String token)
5. 이러한 수정사항에 따라 로그인, 엑세스토큰 재발급 로직 내에서 조건문을 수정했습니다. 
    - jwtProvider.isTokenExpired(refreshToken) -> !jwtProvider.isTokenValid(refreshToken)
