### PR TITLE
feat : 로그아웃, 회원탈퇴 시 사용하던 엑세스토큰을  만료시간 전까지 Redis에 블랙리스트로 넣어 사용할 수 없도록 추가

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
+++ b/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
@@ -18,8 +18,8 @@ import community.ddv.domain.user.service.UserService;
 import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.HashMap;
 import java.util.Map;
@@ -73,8 +73,8 @@ public class UserController {
 
   @Operation(summary = "로그아웃")
   @DeleteMapping("/logout")
-  public ResponseEntity<Void> logout() {
-    userService.logout();
+  public ResponseEntity<Void> logout(HttpServletRequest request) {
+    userService.logout(request);
     return ResponseEntity.noContent().build();
   }
 

--- a/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
+++ b/ddv/src/main/java/community/ddv/domain/user/controller/UserController.java
@@ -82,9 +82,9 @@ public class UserController {
   @Operation(summary = "회원탈퇴")
   @PostMapping("/me")
   public ResponseEntity<Void> deleteAccount(
-      @RequestBody @Valid AccountDeleteDto accountDeleteDto
+      @RequestBody @Valid AccountDeleteDto accountDeleteDto, HttpServletRequest request
   ) {
-    userService.deleteAccount(accountDeleteDto);
+    userService.deleteAccount(accountDeleteDto, request);
     return ResponseEntity.noContent().build();
   }
 

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -24,6 +24,7 @@ import community.ddv.domain.user.repository.UserRepository;
 import community.ddv.global.component.JwtProvider;
 import community.ddv.global.exception.DeepdiviewException;
 import community.ddv.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -47,7 +48,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserRepository userRepository;
-  private final RedisTemplate<String, String> redisRefreshTokenTemplate;
+  private final RedisTemplate<String, String> redisTokenTemplate;
   private final PasswordEncoder passwordEncoder;
   private final JwtProvider jwtProvider;
   private final ReviewRepository reviewRepository;
@@ -112,7 +113,7 @@ public class UserService {
     // 엑세스 토큰 생성
     String accessToken = jwtProvider.generateAccessToken(user.getEmail(), user.getRole());
 
-    String refreshToken = redisRefreshTokenTemplate.opsForValue().get(user.getEmail());
+    String refreshToken = redisTokenTemplate.opsForValue().get(user.getEmail());
     // 리프레시 토큰 생성 (없거나 만료되었으면 새로 생성)
     if (refreshToken == null || !jwtProvider.isTokenValid(refreshToken)) {
       refreshToken = generateAndStoreRefreshToken(user);
@@ -135,7 +136,7 @@ public class UserService {
   private String generateAndStoreRefreshToken(User user) {
     String newRefreshToken = jwtProvider.generateRefreshToken(user.getEmail(), user.getRole());
     // set(키, 값, 숫자, TimeUnit)으로  일정시간(15일) 후 자동 삭제되는 토큰 저장
-    redisRefreshTokenTemplate.opsForValue().set(user.getEmail(), newRefreshToken, 15, TimeUnit.DAYS);
+    redisTokenTemplate.opsForValue().set(user.getEmail(), newRefreshToken, 15, TimeUnit.DAYS);
     return newRefreshToken;
   }
 
@@ -143,7 +144,7 @@ public class UserService {
    * 로그아웃
    */
   @Transactional
-  public void logout() {
+  public void logout(HttpServletRequest request) {
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
     String email = auth.getName();
     log.info("로그아웃 요청");
@@ -153,13 +154,32 @@ public class UserService {
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.USER_NOT_FOUND));
 
     // 리프레시 토큰 삭제
-    Boolean deletedRefreshToken = redisRefreshTokenTemplate.delete(email);
+    Boolean deletedRefreshToken = redisTokenTemplate.delete(email);
     // NullPointException 방지를 위해 Boolean 객체 사용
     if (Boolean.TRUE.equals(deletedRefreshToken)) {
       log.info("리프레시 토큰 삭제 완료");
     } else {
       log.warn("로그아웃 실패");
     }
+
+    // 기존의 엑세스토큰은 블랙리스트로 등록
+    String accessToken = jwtProvider.extractToken(request);
+
+    if (accessToken != null) {
+      // 남은 시간 = 만료시간 - 현재시간
+      long remainTime = jwtProvider.getExpirationTimeFromToken(accessToken) - System.currentTimeMillis();
+
+      if (remainTime > 0) {
+        // 남은 시간동안 블랙리스트로 등록
+        redisTokenTemplate.opsForValue().set(accessToken, "logout", remainTime, TimeUnit.MILLISECONDS);
+        log.info("엑세스토큰 블랙리스트로 등록 완료");
+      } else {
+        log.info("만료된 엑세스 토큰");
+      }
+    } else {
+      log.warn("엑세스토큰이 존재하지 않음");
+    }
+
     // SecurityContext 초기화
     SecurityContextHolder.clearContext();
     log.info("로그아웃 성공");
@@ -179,7 +199,7 @@ public class UserService {
 
     // 리프레시 토큰에서 이메일 추출 후, Redis에 저장된 토큰과 일치 여부 확인
     String email = jwtProvider.extractEmail(refreshToken);
-    String storedRefreshToken = redisRefreshTokenTemplate.opsForValue().get(email);
+    String storedRefreshToken = redisTokenTemplate.opsForValue().get(email);
     if(!refreshToken.equals(storedRefreshToken)) {
       throw new DeepdiviewException(ErrorCode.INVALID_REFRESH_TOKEN);
     }
@@ -214,7 +234,7 @@ public class UserService {
       throw new DeepdiviewException(ErrorCode.NOT_VALID_PASSWORD);
     }
 
-    redisRefreshTokenTemplate.delete(user.getEmail());
+    redisTokenTemplate.delete(user.getEmail());
     log.info("리프레시 토큰 삭제");
 
     // 사용자 삭제

--- a/ddv/src/main/java/community/ddv/global/component/JwtProvider.java
+++ b/ddv/src/main/java/community/ddv/global/component/JwtProvider.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import java.util.List;
 import javax.crypto.SecretKey;
@@ -33,6 +34,9 @@ public class JwtProvider {
   private static final long ACCESS_TOKEN_EXPIRED_TIME = 1000 * 60 * 60;
   // 리프레시 토큰 만료시간 : 15일
   private static final long REFRESH_TOKEN_EXPIRED_TIME = 1000 * 60 * 60 * 24 * 15;
+
+  public static final String TOKEN_HEADER = "Authorization";
+  public static final String TOKEN_PREFIX = "Bearer ";
 
   @PostConstruct
   public void init() {
@@ -72,6 +76,16 @@ public class JwtProvider {
         .getPayload();
   }
 
+  public String extractToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader(TOKEN_HEADER);
+    if (bearerToken != null && bearerToken.startsWith(TOKEN_PREFIX)) {
+      // "Bearer " 부분을 제외하고 토큰만 반환
+      return bearerToken.substring(TOKEN_PREFIX.length());
+    }
+    // 토큰이 존재하지 않거나, "Bearer "로 시작하지 않는 경우 null 반환
+    return null;
+  }
+
   // 토큰에서 이메일 추출
   public String extractEmail(String token) {
     return extractClaims(token).getSubject();
@@ -82,6 +96,11 @@ public class JwtProvider {
     return Role.valueOf(extractClaims(token).get("role", String.class));
   }
 
+  // 토큰에서 만료시간 추출
+  public long getExpirationTimeFromToken(String token) {
+    return extractClaims(token).getExpiration().getTime();
+  }
+
   // 토큰 파싱해서 Authentication 객체 반환
   public Authentication getAuthentication(String token) {
     String email = extractEmail(token);
@@ -89,38 +108,6 @@ public class JwtProvider {
     List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role.name()));
     return new UsernamePasswordAuthenticationToken(email, null, authorities);
   }
-
-//  // 토큰 유효성 검사 (1)
-//  public void validateToken(String token, String email) {
-//
-//    try {
-//      String extractedEmail = extractEmail(token);
-//      if (!extractedEmail.equals(email)) {
-//        throw new JwtException("유효하지 않은 토큰입니다.");
-//      }
-//
-//      if (isTokenExpired(token)) {
-//        throw new ExpiredJwtException(null, null, "만료된 토큰입니다.");
-//      }
-//    } catch (ExpiredJwtException e) {
-//      log.warn("JWT 토큰 만료" + e.getMessage());
-//      throw e;
-//    } catch (JwtException e) {
-//      log.warn("JWT 토큰 검증 실패" + e.getMessage());
-//      throw e;
-//    }
-//  }
-//
-//  // 토큰 유효성 검사 (2)
-//  public boolean validateToken(String token) {
-//    try {
-//      return !isTokenExpired(token);
-//    } catch (JwtException e) {
-//      log.warn("JWT 토큰 검증 실패: " + e.getMessage());
-//      return false;
-//    }
-//  }
-
 
   // 토큰이 유효한지 검증하는 메서드
   public boolean validateToken(String token) {
@@ -135,17 +122,6 @@ public class JwtProvider {
       throw e;
     }
   }
-
-  //
-//  // 토큰 만료 여부 확인
-//  public boolean isTokenExpired(String token) {
-//    try {
-//      return extractClaims(token).getExpiration().before(new Date());
-//    } catch (ExpiredJwtException e) {
-//      log.warn("만료된 JWT 토큰");
-//      return true;
-//    }
-//  }
 
   // 토큰 유효성 여부 확인 후 T/F 반환
   public boolean isTokenValid(String token) {

--- a/ddv/src/main/java/community/ddv/global/config/RedisConfig.java
+++ b/ddv/src/main/java/community/ddv/global/config/RedisConfig.java
@@ -34,7 +34,7 @@ public class RedisConfig {
 
   // 리프레시 토큰 용 RedisTemplate
   @Bean
-  RedisTemplate<String, String> redisRefreshTokenTemplate() {
+  RedisTemplate<String, String> redisTokenTemplate() {
     RedisTemplate<String, String> template = new RedisTemplate<>();
     template.setConnectionFactory(redisConnectionFactory());
     template.setKeySerializer(new StringRedisSerializer());
@@ -52,7 +52,7 @@ public class RedisConfig {
   }
 
   @Bean
-  public CacheManager rediscacheManager(RedisConnectionFactory factory) {
+  public CacheManager redisCacheManager(RedisConnectionFactory factory) {
 
     // ObjectMapper 설정
     ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
# [변경배경]
- 로그아웃 및 회원탈퇴 후에도 기존 AccessToken으로 접근이 가능한 이슈가 있었습니다.
- SecurityContext 초기화가 토큰 자체의 무효화를 보장하지는 않았습니다. 

# [변경내용]
- RedisTemplate를 이용하여 사용하던 AccessToken을 블랙리스트로 등록
  - 로그아웃 및 회원탈퇴 시, 사용 중이던 AccessToken을 블랙리스트에 추가
  - 토큰의 만료시간까지 블랙리스트에 보관하여 재사용 차단

