### PR TITLE
feat : 인기도 20위 영화 조회 api 호출시 한국어 혹은 영어 제목만 가진 영화만 나오도록 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
@@ -46,8 +46,18 @@ public class MovieService {
     Page<Movie> topMovies = movieRepository.findAllByOrderByPopularityDesc(pageable);
     log.info("인기도 탑{} 영화 조회 성공", size);
     return topMovies.stream()
+        .filter(movie -> isKoreanOrEnglishTitle(movie.getTitle()))
         .map(this::convertToDtoWithoutReviews)
         .collect(Collectors.toList());
+  }
+
+  private boolean isKoreanOrEnglishTitle(String title) {
+    if (title == null) return false;
+
+    boolean containsKorean = title.matches(".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*");
+    boolean isEnglishOnly = title.matches("^[a-zA-Z0-9\\s.,!?\"'\\-:()]+$");
+
+    return containsKorean || isEnglishOnly;
   }
 
   /**


### PR DESCRIPTION
# [변경사항]

- 넷플릭스 KR에서 제공하지 않는 영화들이 나오는 이슈 발생 
  - 정규식을 활용하여 제목이 한국어거나 영어인 영화만 호출이 되도록 수정했습니다. 
