### PR TITLE
feat : 영화 정보 조회 시, 현재 넷플릭스에서 제공하고 있는지 여부도 함께 반환하도록 추가

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/movie/controller/ApiController.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/controller/ApiController.java
@@ -27,7 +27,7 @@ public class ApiController {
     return "API로부터 장르 정보 받아오기 성공";
   }
 
-  // 장르 정보 저장
+  // 영화 정보 저장
   @Operation(summary = "DB 초기화했을 때 후순위 저장", description = "평소에는 사용하지 않으셔도 됩니다.")
   @GetMapping("/movies")
   public String fetchAndSaveMovies() {

--- a/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
@@ -27,4 +27,6 @@ public class MovieDTO {
   private ReviewResponseDTO myReview;
   private Double ratingAverage;
 
+  private boolean isAvailable;
+
 }

--- a/ddv/src/main/java/community/ddv/domain/movie/repostitory/MovieRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/repostitory/MovieRepository.java
@@ -13,9 +13,11 @@ import org.springframework.stereotype.Repository;
 public interface MovieRepository extends JpaRepository<Movie, Long> {
 
   // 넷플릭스 내 인기도 상위 n개의 영화정보 조회
-  Page<Movie> findAllByOrderByPopularityDesc(Pageable pageable);
+  //Page<Movie> findAllByOrderByPopularityDesc(Pageable pageable);
+  Page<Movie> findAllByAvailableIsTrueOrderByPopularityDesc(Pageable pageable);
 
   // 특정 단어가 포함된 영화 정보 리스트 조회(공백 무시)
+  //@Query("SELECT m FROM Movie m WHERE REPLACE(m.title, ' ', '') LIKE CONCAT('%', REPLACE(:title, ' ', ''), '%') AND m.isAvailable = true ORDER BY m.popularity DESC")
   @Query("SELECT m FROM Movie m WHERE REPLACE(m.title, ' ', '') LIKE CONCAT('%', REPLACE(:title, ' ', ''), '%') ORDER BY m.popularity DESC")
   Page<Movie> findByTitleFlexible(@Param("title") String title, Pageable pageable);
 

--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
@@ -43,7 +43,7 @@ public class MovieService {
    */
   public List<MovieDTO> getTopMovies(int size) {
     Pageable pageable = PageRequest.of(0, size);
-    Page<Movie> topMovies = movieRepository.findAllByOrderByPopularityDesc(pageable);
+    Page<Movie> topMovies = movieRepository.findAllByAvailableIsTrueOrderByPopularityDesc(pageable);
     log.info("인기도 탑{} 영화 조회 성공", size);
     return topMovies.stream()
         .filter(movie -> isKoreanOrEnglishTitle(movie.getTitle()))
@@ -177,6 +177,7 @@ public class MovieService {
         .reviews(reviews != null ? reviews : Collections.emptyList())
         .myReview(myReview)
         .ratingAverage(ratingAverage)
+        .isAvailable(movie.isAvailable())
         .build();
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -122,15 +122,15 @@ public class UserService {
     }
 
     log.info("로그인 성공");
-    return new LoginResponseDto(
-        accessToken,
-        refreshToken,
-        user.getId(),
-        user.getEmail(),
-        user.getNickname(),
-        user.getProfileImageUrl(),
-        user.getRole()
-    );
+    return LoginResponseDto.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .userId(user.getId())
+        .email(user.getEmail())
+        .nickname(user.getNickname())
+        .profileImageUrl(user.getProfileImageUrl())
+        .role(user.getRole())
+        .build();
   }
 
   private String generateAndStoreRefreshToken(User user) {


### PR DESCRIPTION
# [변경사항]

- 넷플릭스에서 제공하는 영화를 대상으로 하는 서비스임에도 불구하고 넷플릭스에서 내려간 영화도 함께 조회되는 이슈
  - 영화 상세 정보에 boolean으로 현재 제공중인지 여부를 함께 반환하도록 수정했습니다.   
  - 인기도 n위에는 넷플릭스에서 내려간 영화 정보는 나오지 않도록 했습니다.
  - 검색은 가능합니다. 다만, 뱃지를 달아 현재 넷플릭스에서 제공 중인지 여부를 표시할 예정입니다.  
