### PR TITLE
refactor : 기존의 sse 연결을 명시적으로 종료하도록 추가, 새로운 emitter를 종료하거나 타임아웃 시에는 현재 emitter가 동일한 경우에만 제거하도록 수정 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -50,6 +50,7 @@ public class NotificationService {
     SseEmitter previousEmitter = emitters.remove(userId);
     if (previousEmitter != null) {
       log.info("기존 emitter 존재 -> 제거 완료 userId = {}", userId);
+      previousEmitter.complete();
     }
 
     // 2. 새 emitter 저장


### PR DESCRIPTION
# [변경사항]

1. 기존의 sse를 명시적으로 complete()하지 않았던 것을 추가해 넣었습니다. 
2. 기존의 연결을 complete() 했더니 새로운 emitter까지 제거되는 문제가 발생하여, 현재의 emitter와 제거하려고 하는 emitter가 동일할 때만 제거되도록 수정했습니다. 