### PR TITLE
fix : 인기도 n위 영화 조회시, 제목이 영어나 한국어가 아닌 것이 필터링되어 n-k개만 조회되는 이슈 해결 & refactor : 리뷰 최신순 n개 -> 최신순 조회로 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
@@ -92,10 +92,15 @@ public class ReviewController {
     return ResponseEntity.ok(reviewService.getReviewById(reviewId));
   }
 
-  @Operation(summary = "최신 리뷰 3개 조회")
+  @Operation(summary = "최신 리뷰 조회", description = "디폴트 사이즈는 9입니다.")
   @GetMapping("/latest")
-  public ResponseEntity<List<ReviewResponseDTO>> getLatestReviews() {
-    return ResponseEntity.ok(reviewService.getLatestReviews());
+  public ResponseEntity<Page<ReviewResponseDTO>> getLatestReviews(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "9") int size
+  ) {
+    Sort sortOrder = Sort.by(Sort.Order.desc("createdAt"));
+    Pageable pageable = PageRequest.of(page, size, sortOrder);
+    return ResponseEntity.ok(reviewService.getLatestReviews(pageable));
   }
 
   @Operation(summary = "좋아요", description = "토글형식입니다. 두 번 누를 시 좋아요 취소")

--- a/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
@@ -18,6 +18,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   Page<Review> findByUser_IdAndCertifiedTrue(Long userId, Pageable pageable);
   Page<Review> findByMovieAndCertifiedTrue(Movie movie, Pageable pageable);
   List<Review> findAllByUser_Id(Long userId);
-  List<Review> findTop3ByOrderByCreatedAtDesc();
+  Page<Review> findAllByOrderByCreatedAtDesc(Pageable pageable);
   Optional<Review> findByUserAndMovie(User user, Movie movie);
 }

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -181,11 +181,9 @@ public class ReviewService {
 
   // 최신 리뷰 3개 조회
   @Transactional(readOnly = true)
-  public List<ReviewResponseDTO> getLatestReviews() {
-    List<Review> reviews = reviewRepository.findTop3ByOrderByCreatedAtDesc();
-    return reviews.stream()
-        .map(this::convertToReviewResponseDto)
-        .collect(Collectors.toList());
+  public Page<ReviewResponseDTO> getLatestReviews(Pageable pageable) {
+    Page<Review> reviews = reviewRepository.findAllByOrderByCreatedAtDesc(pageable);
+    return reviews.map(this::convertToReviewResponseDto);
   }
 
 

--- a/ddv/src/main/java/community/ddv/domain/movie/repostitory/MovieRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/repostitory/MovieRepository.java
@@ -1,6 +1,7 @@
 package community.ddv.domain.movie.repostitory;
 
 import community.ddv.domain.movie.entity.Movie;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,8 +14,13 @@ import org.springframework.stereotype.Repository;
 public interface MovieRepository extends JpaRepository<Movie, Long> {
 
   // 넷플릭스 내 인기도 상위 n개의 영화정보 조회
-  //Page<Movie> findAllByOrderByPopularityDesc(Pageable pageable);
-  Page<Movie> findAllByAvailableIsTrueOrderByPopularityDesc(Pageable pageable);
+  @Query(
+      value = "SELECT * FROM movie WHERE is_available = true AND + "
+          + "(title REGEXP '[ㄱ-ㅎㅏ-ㅣ가-힣]' OR title REGEXP '^[a-zA-Z0-9\\s.,!?\"''\\-:()]+') " +
+          "ORDER BY popularity DESC " +
+          "LIMIT :limit",
+      nativeQuery = true)
+  List<Movie> findAllByAvailableIsTrueOrderByPopularityDesc(@Param("limit") int limit);
 
   // 특정 단어가 포함된 영화 정보 리스트 조회(공백 무시)
   //@Query("SELECT m FROM Movie m WHERE REPLACE(m.title, ' ', '') LIKE CONCAT('%', REPLACE(:title, ' ', ''), '%') AND m.isAvailable = true ORDER BY m.popularity DESC")

--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
@@ -42,22 +42,11 @@ public class MovieService {
    * @param size
    */
   public List<MovieDTO> getTopMovies(int size) {
-    Pageable pageable = PageRequest.of(0, size);
-    Page<Movie> topMovies = movieRepository.findAllByAvailableIsTrueOrderByPopularityDesc(pageable);
+    List<Movie> topMovies = movieRepository.findAllByAvailableIsTrueOrderByPopularityDesc(size);
     log.info("인기도 탑{} 영화 조회 성공", size);
     return topMovies.stream()
-        .filter(movie -> isKoreanOrEnglishTitle(movie.getTitle()))
         .map(this::convertToDtoWithoutReviews)
         .collect(Collectors.toList());
-  }
-
-  private boolean isKoreanOrEnglishTitle(String title) {
-    if (title == null) return false;
-
-    boolean containsKorean = title.matches(".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*");
-    boolean isEnglishOnly = title.matches("^[a-zA-Z0-9\\s.,!?\"'\\-:()]+$");
-
-    return containsKorean || isEnglishOnly;
   }
 
   /**


### PR DESCRIPTION
# [변경사항]

- 인기도 n개 영화 조회시, DB에서 n개의 영화를 조회해왔으나, 제목에 한글이나 영어가 없는 경우는 통과하는 필터링 메서드가 적용되어 제목에 인도어가 들어가 있는 경우, n개가 아닌 n-k개의 영화가 조회되는 이슈 발생 
  - DB에서 데이터를 불러올 때 먼저 필터링을 하는 것이 올바른 순서라고 생각
  - 레포지토리에서 정규식을 활용하기 위해 네이티브 쿼리를 사용했습니다. 
  
- 최신순 리뷰 3개 조회 -> 최신순 리뷰 조회로 수정했습니다. 
  - 디폴트 사이즈는 9개입니다.  
