### PR TITLE
feat : 영화 정보 조회시, 각 영화별 별점 분포가 함께 반환되도록 추가

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import community.ddv.domain.board.dto.ReviewResponseDTO;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,6 +30,8 @@ public class MovieDTO {
   private ReviewResponseDTO myReview;
   private Double ratingAverage;
 
-  private boolean isAvailable;
+  private boolean isAvailable; // 현재 제공 중인지 여부
+
+  private Map<Double, Integer> ratingDistribution; // 별점 분포
 
 }


### PR DESCRIPTION
# [변경사항]

- 영화정보 조회시, 각 영화의 리뷰에 달린 별점 분포가 함께 반환됩니다. 
- 다음과 같이 반환됩니다. 
 ```  "ratingAverage": 4.333333333333333,
  "ratingDistribution": {
    "0.5": 0,
    "1.0": 0,
    "1.5": 0,
    "2.0": 0,
    "2.5": 0,
    "3.0": 0,
    "3.5": 0,
    "4.0": 1,
    "4.5": 2,
    "5.0": 0
  }
```
- 0.5부터 5.0까지 순서대로 출력되며, 받지 않은 점수의 경우 0개로 초기화 되어 나옵니다. 
