### PR TITLE
refactor :  승인 APPROVED된 사용자도 자신의 인증샷 url과 상태를 반환받을 수 있도록 수정, fix :   지난 주 1위 영화 가져오는 메서드에서 투표를 가져오는 방식 변경 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -22,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -79,7 +78,7 @@ public class CertificationService {
   }
 
   /**
-   * PENDING/REJECT 상태의 사용자 _ 자신이 올린 사진 URL, 상태 반환
+   * 자신이 올린 사진 URL, 상태 반환
    */
   @Transactional(readOnly = true)
   public CertificationResponseDto getMyCertification() {
@@ -106,15 +105,14 @@ public class CertificationService {
           .build();
     }
 
-    // PENDING 또는 REJECTED 상태에서만 반환
     CertificationStatus status = certification.getStatus();
+
     if (status == null) {
       throw new DeepdiviewException(ErrorCode.CERTIFICATION_NOT_FOUND);
     }
-    if (status.equals(CertificationStatus.APPROVED)) {
-      throw new DeepdiviewException(ErrorCode.ALREADY_APPROVED);
-    }
-
+//    if (status.equals(CertificationStatus.APPROVED)) {
+//      throw new DeepdiviewException(ErrorCode.ALREADY_APPROVED);
+//    }
     return convertToCertificationDto(certification);
   }
 

--- a/ddv/src/main/java/community/ddv/global/component/Scheduler.java
+++ b/ddv/src/main/java/community/ddv/global/component/Scheduler.java
@@ -37,7 +37,7 @@ public class Scheduler {
   }
 
   // 지난 주 1위 영화 캐시 초기화
-  @Scheduled(cron = "0 0 0 * * MON")
+  @Scheduled(cron = "0 0 0 * * SUN")
   public void clearTopRankMovieCache() {
     Cache topVotedCache = cacheManager.getCache("topRankMovie");
 


### PR DESCRIPTION
# [변경사항]

- APPROVE 상태의 사용자가 GET /api/certifications/me 호출시 반환값을 변경했습니다. 
  - `{ "errorCode": "ALREADY_APPROVED", "errorMessage": "이미 승인되었습니다." }` 
  -> PENDING, REJECTED 사용자와 동일하게 반환

-----

- 지난 주 1위 영화를 DB에서 가져오는 방식 변경 
  - 지난주 평일에 진행한 투표 -> 지난주 일요일에 생성한 투표
