### PR TITLE
feat : Movie 엔티티에 runtime 컬럼을 신설하여 영화 조회시 함께 나오도록 추가

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/movie/controller/ApiController.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/controller/ApiController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,11 +30,18 @@ public class ApiController {
 
   // 영화 정보 저장
   @Operation(summary = "DB 초기화했을 때 후순위 저장", description = "평소에는 사용하지 않으셔도 됩니다.")
-  @GetMapping("/movies")
+  @PostMapping("/movies")
   public String fetchAndSaveMovies() {
 
     movieApiService.fetchAndSaveMovies();
     return "API로부터 영화세부 정보 받아오기 성공";
+  }
+
+  @Operation(summary = "런타임 저장")
+  @PostMapping("/runtimes")
+  public String fetchAndSaveRuntimes() {
+    movieApiService.fetchMovieRunTime();;
+    return "런타임 업데이트 완료";
   }
 
 }

--- a/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
@@ -20,6 +20,7 @@ public class MovieDTO {
   private String overview;        // 즐거리
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   private LocalDate release_date; // 개봉일
+  private Integer runtime;        // 런타임
   private Double popularity;      // 인기도
   private String poster_path;     // 포스터 url
   private String backdrop_path;   // 백드롭이미지 url

--- a/ddv/src/main/java/community/ddv/domain/movie/entity/Movie.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/entity/Movie.java
@@ -41,6 +41,14 @@ public class Movie {
   private String overview;       // 즐거리
 
   private LocalDate releaseDate; // 개봉일
+
+  private Integer runtime; // 런타임
+  public void updateRuntime(Integer runtime) {
+    if (this.runtime == null) {
+      this.runtime = runtime;
+    }
+  }
+
   @Setter
   private Double popularity;     // 인기도
   private String posterPath;     // 포스터 url

--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
@@ -170,6 +170,7 @@ public class MovieService {
         .original_title(movie.getOriginalTitle())
         .overview(movie.getOverview())
         .release_date(movie.getReleaseDate())
+        .runtime(movie.getRuntime())
         .popularity(movie.getPopularity())
         .poster_path(movie.getPosterPath())
         .backdrop_path(movie.getBackdropPath())

--- a/ddv/src/main/java/community/ddv/global/component/Scheduler.java
+++ b/ddv/src/main/java/community/ddv/global/component/Scheduler.java
@@ -24,8 +24,15 @@ public class Scheduler {
     log.info("영화정보 업데이트를 시작합니다.");
     movieApiService.fetchAndSaveMovies();
     log.info("영화정보 업데이트를 완료했습니다.");
-
     clearTopMoviesCache();
+  }
+
+  // 매주 월요일 0시 2분에 런타임 데이터 업데이트
+  @Scheduled(cron = "0 2 0 * * MON")
+  public void updateMovieRuntimeApi() {
+    log.info("런타임정보 업데이트를 시작합니다.");
+    movieApiService.fetchMovieRunTime();
+    log.info("런타임정보 업데이트를 완료했습니다.");
   }
 
   public void clearTopMoviesCache() {
@@ -50,7 +57,6 @@ public class Scheduler {
   // 매주 일요일 0시, 인증상태 초기화 스케줄링
   @Scheduled(cron = "0 0 0 * * SUN")
   public void resetCertificationStatus() {
-    log.info("");
     certificationService.resetCertificationStatus();
   }
 

--- a/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
       "/api/users/login",
       "/api/fetch/genres",
       "/api/fetch/movies",
+      "/api/fetch/runtimes",
       "/api/movies/**",
       "/api/discussions/is-sunday",
       "/api/discussions/this-week-movie",


### PR DESCRIPTION
# [변경사항]

- TMDB에서 tmdbId별로 runtime(상영시간)을 받아오는 API 호출 로직을 구현했습니다.
  - Movie  엔티티에 runtime 컬럼을 신설하여 상영시간 데이터를 저장합니다.. 
    - 이를 통해 영화 정보를 조회할 때, 상영시간도 함께 반환 받게 됩니다.

- API 호출 방식을 GET -> POST 메서드로 수정했습니다. 
  - 데이터 변경이 발생하기 때문에 POST가 적합하다고 판단했습니다. 
