### PR TITLE
fix : 영화 정보 조회시, 별점 평균과 분포가 제대로 나오지 않은 이슈 해결

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/dto/ReviewRatingDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/board/dto/ReviewRatingDTO.java
@@ -1,0 +1,16 @@
+package community.ddv.domain.board.dto;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class ReviewRatingDTO {
+  private Double ratingAverage;
+  private Map<Double, Integer> ratingDistribution;
+}

--- a/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
@@ -14,6 +14,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   boolean existsByUserAndMovie(User user, Movie movie);
   int countByUser_Id(Long userId);
   Page<Review> findByMovie(Movie movie, Pageable pageable);
+  List<Review> findByMovie(Movie movie);
   Page<Review> findByUser_Id(Long userId, Pageable pageable);
   Page<Review> findByUser_IdAndCertifiedTrue(Long userId, Pageable pageable);
   Page<Review> findByMovieAndCertifiedTrue(Movie movie, Pageable pageable);

--- a/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
@@ -1,10 +1,10 @@
 package community.ddv.domain.movie.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import community.ddv.domain.board.dto.ReviewRatingDTO;
 import community.ddv.domain.board.dto.ReviewResponseDTO;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,10 +29,9 @@ public class MovieDTO {
 
   private List<ReviewResponseDTO> reviews;
   private ReviewResponseDTO myReview;
-  private Double ratingAverage;
+  private ReviewRatingDTO ratingStats; // 별점 정보 (평균, 분포)
 
   private boolean isAvailable; // 현재 제공 중인지 여부
 
-  private Map<Double, Integer> ratingDistribution; // 별점 분포
 
 }


### PR DESCRIPTION
# [문제상황]
 - 특정 영화 정보 조회시, 리뷰에 전체에 대한 별점 평균/분포가 제대로 나오지 않고 5개에 맞춰 잘려 나오면서 실제적인 데이터와 다른 문제 발생
 
# [원인]
- 특정 영화 정보 조회시, 해당 영화에 대한 최신리뷰 5개를 함께 반환하는 로직의 존재
  - 그 5개의 리뷰에서 계산된 평균별점, 별점 분포를 구해오면서 일관적인 데이터가 반환되지 않음 

# [해결]
  - ReviewService 내에 별점 평균, 분포를 구하는 메서드 getRatingsByMovie(Movie movie) 를 따로 작성 
  - movieService의 convertToDto() 수정
    -> convertToDto()가 사용되는 모든 곳에 전체 리뷰들로부터 계산된 평균과 분포를 반환하도록 수정
