### PR TITLE
refactor : 최신 리뷰 조회 시 N+1 문제 해결을 위한 Fetch Join 처리, 평균별점 구하는 방식 변경 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
@@ -9,26 +9,40 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
   boolean existsByUserAndMovie(User user, Movie movie);
+
   int countByUser_Id(Long userId);
+
   Page<Review> findByMovie(Movie movie, Pageable pageable);
+
   List<Review> findByMovie(Movie movie);
+
   Page<Review> findByUser_Id(Long userId, Pageable pageable);
+
   Page<Review> findByUser_IdAndCertifiedTrue(Long userId, Pageable pageable);
+
   Page<Review> findByMovieAndCertifiedTrue(Movie movie, Pageable pageable);
+
   List<Review> findAllByUser_Id(Long userId);
+
   //Page<Review> findAllByOrderByCreatedAtDesc(Pageable pageable);
   @Query(
       value = """
-    select distinct r from Review r
-    join fetch r.user u
-    join fetch r.movie m
-  """,
+            select distinct r from Review r
+            join fetch r.user u
+            join fetch r.movie m
+          """,
       countQuery = "select count(r) from Review r"
   )
   Page<Review> findLatestReviews(Pageable pageable);
+
   Optional<Review> findByUserAndMovie(User user, Movie movie);
+
+  @Query("select avg(r.rating) from Review r where r.movie = :movie")
+  Double findAverageRatingByMovie(@Param("movie") Movie movie);
+
 }

--- a/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
@@ -19,6 +20,17 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   Page<Review> findByUser_IdAndCertifiedTrue(Long userId, Pageable pageable);
   Page<Review> findByMovieAndCertifiedTrue(Movie movie, Pageable pageable);
   List<Review> findAllByUser_Id(Long userId);
-  Page<Review> findAllByOrderByCreatedAtDesc(Pageable pageable);
+  //Page<Review> findAllByOrderByCreatedAtDesc(Pageable pageable);
+  @Query(
+      value = """
+    select distinct r from Review r
+    join fetch r.user u
+    join fetch r.movie m
+    left join fetch r.comments c
+    left join fetch c.user
+  """,
+      countQuery = "select count(r) from Review r"
+  )
+  Page<Review> findLatestReviews(Pageable pageable);
   Optional<Review> findByUserAndMovie(User user, Movie movie);
 }

--- a/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
@@ -26,8 +26,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     select distinct r from Review r
     join fetch r.user u
     join fetch r.movie m
-    left join fetch r.comments c
-    left join fetch c.user
   """,
       countQuery = "select count(r) from Review r"
   )

--- a/ddv/src/main/java/community/ddv/domain/board/service/CommentService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/CommentService.java
@@ -109,9 +109,8 @@ public class CommentService {
     Review review = reviewRepository.findById(reviewId)
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
 
-    Page<Comment> comments = commentRepository.findByReview(review, pageable);
-
-    return comments.map(this::convertToCommentResponse);
+    return commentRepository.findByReview(review, pageable)
+        .map(this::convertToCommentResponse);
   }
 
   @Transactional(readOnly = true)
@@ -119,9 +118,8 @@ public class CommentService {
     log.info("특정 이용자 {}가 작성한 댓글 조회 요청", userId);
     userService.getLoginUser();
 
-    Page<Comment> comments = commentRepository.findByUser_Id(userId, pageable);
-
-    return comments.map(this::convertToCommentResponse);
+    return commentRepository.findByUser_Id(userId, pageable)
+        .map(this::convertToCommentResponse);
   }
 
 

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -184,16 +184,19 @@ public class ReviewService {
 
   }
 
-  // 최신 리뷰 조회
+
+  /**
+   * 최신순 리뷰 n개 조회
+   */
   @Transactional(readOnly = true)
   public PageResponse<ReviewResponseDTO> getLatestReviews(Pageable pageable) {
-    Page<Review> reviews = reviewRepository.findAllByOrderByCreatedAtDesc(pageable);
+    Page<Review> reviews = reviewRepository.findLatestReviews(pageable);
     Page<ReviewResponseDTO> reviewResponseDTOS = reviews.map(this::convertToReviewResponseDto);
     return new PageResponse<>(reviewResponseDTOS);
   }
 
 
-  // 특정 영화의 평균별점, 별점 분포 조회
+  // 특정 영화의 평균별점, 별점 분포 조회 메서드
   public ReviewRatingDTO getRatingsByMovie(Movie movie) {
 
     List<Review> reviews = reviewRepository.findByMovie(movie);

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -196,18 +196,24 @@ public class ReviewService {
   // 특정 영화의 평균별점, 별점 분포 조회 메서드
   public ReviewRatingDTO getRatingsByMovie(Movie movie) {
 
-    List<Review> reviews = reviewRepository.findByMovie(movie);
-    if (reviews.isEmpty()) {
-      return new ReviewRatingDTO(0.0, initializeRatingDistribution());
-    }
+//    if (reviews.isEmpty()) {
+//      return new ReviewRatingDTO(0.0, initializeRatingDistribution());
+//    }
+//
+//    double ratingAverage = reviews.stream()
+//        .map(Review::getRating)
+//        .filter(Objects::nonNull)
+//        .mapToDouble(Double::doubleValue)
+//        .average()
+//        .orElse(0.0);
 
     // 평균 별점
-    double ratingAverage = reviews.stream()
-        .map(Review::getRating)
-        .filter(Objects::nonNull)
-        .mapToDouble(Double::doubleValue)
-        .average()
-        .orElse(0.0);
+    Double ratingAverage = reviewRepository.findAverageRatingByMovie(movie);
+    if (ratingAverage == null) {
+      ratingAverage = 0.0;
+    }
+
+    List<Review> reviews = reviewRepository.findByMovie(movie);
 
     // 별점 분포
     Map<Double, Integer> ratingDistribution = initializeRatingDistribution(); // 별점 분포도

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -64,8 +64,8 @@ public class ReviewService {
         .certified(reviewDTO.isCertified())
         .build();
 
-    Review savedReview = reviewRepository.save(review);
-    return convertToReviewResponseDto(savedReview);
+    reviewRepository.save(review);
+    return convertToReviewResponseWithoutCommentsDto(review);
   }
 
   /**
@@ -113,7 +113,7 @@ public class ReviewService {
         reviewUpdateDTO.getRating()
     );
 
-    return convertToReviewResponseDto(review);
+    return convertToReviewResponseWithoutCommentsDto(review);
 
   }
 
@@ -122,8 +122,7 @@ public class ReviewService {
    * @param tmdbId
    */
   @Transactional(readOnly = true)
-  public Page<ReviewResponseDTO> getReviewByMovieId(Long tmdbId, Pageable pageable,
-      Boolean certifiedFilter) {
+  public Page<ReviewResponseDTO> getReviewByMovieId(Long tmdbId, Pageable pageable, Boolean certifiedFilter) {
 
     Movie movie = movieRepository.findByTmdbId(tmdbId)
         .orElseThrow(() -> {
@@ -140,7 +139,7 @@ public class ReviewService {
       reviews = reviewRepository.findByMovie(movie, pageable);
     }
 
-    return reviews.map(this::convertToReviewResponseDto);
+    return reviews.map(this::convertToReviewResponseWithoutCommentsDto);
   }
 
   /**
@@ -166,9 +165,7 @@ public class ReviewService {
    * @return
    */
   @Transactional(readOnly = true)
-  public Page<ReviewResponseDTO> getReviewsByUserId(Long userId, Pageable pageable,
-      Boolean certifiedFilter) {
-    userService.getLoginUser();
+  public Page<ReviewResponseDTO> getReviewsByUserId(Long userId, Pageable pageable, Boolean certifiedFilter) {
 
     Page<Review> reviews;
 
@@ -180,7 +177,7 @@ public class ReviewService {
       reviews = reviewRepository.findByUser_Id(userId, pageable);
     }
 
-    return reviews.map(this::convertToReviewResponseDto);
+    return reviews.map(this::convertToReviewResponseWithoutCommentsDto);
 
   }
 
@@ -191,7 +188,7 @@ public class ReviewService {
   @Transactional(readOnly = true)
   public PageResponse<ReviewResponseDTO> getLatestReviews(Pageable pageable) {
     Page<Review> reviews = reviewRepository.findLatestReviews(pageable);
-    Page<ReviewResponseDTO> reviewResponseDTOS = reviews.map(this::convertToReviewResponseDto);
+    Page<ReviewResponseDTO> reviewResponseDTOS = reviews.map(this::convertToReviewResponseWithoutCommentsDto);
     return new PageResponse<>(reviewResponseDTOS);
   }
 
@@ -234,7 +231,7 @@ public class ReviewService {
 
 
   // 댓글 포함  X
-  public ReviewResponseDTO convertToReviewResponseDto(Review review) {
+  public ReviewResponseDTO convertToReviewResponseWithoutCommentsDto(Review review) {
     return convertToReviewResponseDtoBase(review, false);
   }
 

--- a/ddv/src/main/java/community/ddv/domain/movie/controller/MovieController.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/controller/MovieController.java
@@ -38,10 +38,9 @@ public class MovieController {
   @GetMapping("/search/list")
   public ResponseEntity<PageResponse<MovieDTO>> getMoviesByTitle(
       @RequestParam("title") String title,
-      @RequestParam(value = "certifiedFilter", required = false, defaultValue = "false") Boolean certifiedFilter,
       @PageableDefault(size = 10, sort = "popularity", direction = Sort.Direction.DESC) Pageable pageable
       ) {
-    Page<MovieDTO> movies = movieService.searchMoviesByTitle(title, certifiedFilter, pageable);
+    Page<MovieDTO> movies = movieService.searchMoviesByTitle(title, pageable);
     return ResponseEntity.ok(new PageResponse<>(movies));
   }
 

--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
@@ -72,7 +72,7 @@ public class MovieService {
    * @param title
    */
   @Transactional(readOnly = true)
-  public Page<MovieDTO> searchMoviesByTitle(String title, Boolean certifiedFilter, Pageable page) {
+  public Page<MovieDTO> searchMoviesByTitle(String title, Pageable page) {
 
     Page<Movie> movies = movieRepository.findByTitleFlexible(title, page);
     if (movies.isEmpty()) {
@@ -80,7 +80,7 @@ public class MovieService {
       throw new DeepdiviewException(ErrorCode.KEYWORD_NOT_FOUND);
     }
 
-    //log.info("영화 제목 '{}'으로 영화의 세부정보 조회 성공", title);
+    log.info("영화 제목 '{}'으로 영화의 세부정보 조회 성공", title);
     return movies
         .map(movie -> {
           ReviewRatingDTO ratingStats = reviewService.getRatingsByMovie(movie);

--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
@@ -110,7 +110,7 @@ public class MovieService {
     if (loginUser != null) {
       Optional<Review> optionalReview = reviewRepository.findByUserAndMovie(loginUser, movie);
       if (optionalReview.isPresent()) {
-        myReview = reviewService.convertToReviewResponseDto(optionalReview.get());
+        myReview = reviewService.convertToReviewResponseWithoutCommentsDto(optionalReview.get());
       }
     }
 

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -199,7 +199,7 @@ public class UserService {
     // 리프레시 토큰에서 이메일 추출 후, Redis에 저장된 토큰과 일치 여부 확인
     String email = jwtProvider.extractEmail(refreshToken);
     String storedRefreshToken = redisTokenTemplate.opsForValue().get(email);
-    if(!refreshToken.equals(storedRefreshToken)) {
+    if (!refreshToken.equals(storedRefreshToken)) {
       throw new DeepdiviewException(ErrorCode.INVALID_REFRESH_TOKEN);
     }
 
@@ -372,11 +372,8 @@ public class UserService {
     LocalDate startOfWeek = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
     LocalDate endOfWeek = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
 
-//    Certification certification = certificationRepository.findTopByUser_IdOrderByCreatedAtDesc(user.getId())
-//        .orElse(null);
-
     Certification certification = certificationRepository
-         // 이번 주(월~토)에 한 인증 중에서 가장 최신 인증 1개 가져오기
+        // 이번 주(월~토)에 한 인증 중에서 가장 최신 인증 1개 가져오기
         .findTopByUser_IdAndCreatedAtBetweenOrderByCreatedAtDesc(
             user.getId(),
             startOfWeek.atStartOfDay(),
@@ -385,13 +382,11 @@ public class UserService {
 
     CertificationStatus certificationStatus =
         certification != null
-            ? certification.getStatus()
-            : null;
+            ? certification.getStatus() : null;
+
     RejectionReason rejectionReason =
         certification != null && certification.getStatus() == CertificationStatus.REJECTED
-            ? certification.getRejectionReason()
-            : null;
-
+            ? certification.getRejectionReason() : null;
 
     return UserInfoResponseDto.builder()
         .nickname(user.getNickname())
@@ -403,7 +398,7 @@ public class UserService {
         .ratingDistribution(ratingDistribution)
         .certificationStatus(certificationStatus)
         .rejectionReason(rejectionReason)
-    .build();
+        .build();
   }
 
   /**
@@ -438,7 +433,6 @@ public class UserService {
   }
 
   // 로그인 여부 확인 메서드
-//  @Transactional(readOnly = true)
   public User getLoginUser() {
 
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -453,7 +447,6 @@ public class UserService {
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.USER_NOT_FOUND));
   }
 
-//  @Transactional(readOnly = true)
   public User getLoginOrNull() {
     try {
       return getLoginUser();


### PR DESCRIPTION
# [변경사항]

1. Review와 관련된 User와 Movie 데이터를 fetch join을 사용하여 불필요한 쿼리 발생을 줄이고 한 번에 로딩하도록 처리했습니다.

2. movieService 내에서 convertToDto~~ 메서드를 삭제하고 convertToDto만 사용하는 것으로 통일했습니다. 
3. 키워드로 영화 조회시, 응답에 리뷰 값은 넣지 않는 것으로 변경 -> 사용하지 않는 파라미터 삭제
4. 별점 평균을 메서드로 구하기보다는 JPQL을 활용하여 단순 계산하도록 수정했습니다. stream.average() -> select avg()~~ 

