### PR TITLE
feat : 이주의 영화의 영화정보만 반환하는 API 작성 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/movie/controller/MovieController.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/controller/MovieController.java
@@ -44,6 +44,14 @@ public class MovieController {
     return ResponseEntity.ok(new PageResponse<>(movies));
   }
 
+  @Operation(summary = "영화 제목 자동완성 5개", description = "특정 글자/단어가 포함되어 있는 영화 제목 5개를 반환합니다. 띄어쓰기를 무시하고도 조회가 됩니다.")
+  @GetMapping("/search/autocomplete")
+  public ResponseEntity<List<String>> autoCompleteMovieTitle(
+      @RequestParam String keyword) {
+    List<String> titles = movieService.autoCompleteTitles(keyword);
+    return ResponseEntity.ok(titles);
+  }
+
   @Operation(summary = "특정 영화 상세정보 조회", description = "tmdb에서 제공하는 id값(tmdbId)을 넣어야 조회됩니다.")
   @GetMapping("/{movieId}")
   public ResponseEntity<MovieDTO> getMovieDetail(
@@ -51,6 +59,15 @@ public class MovieController {
       @RequestParam(value = "certifiedFilter", required = false, defaultValue = "false") Boolean certifiedFilter
       ) {
     MovieDTO movieDetails = movieService.getMovieDetailsById(movieId, certifiedFilter);
+    return ResponseEntity.ok(movieDetails);
+  }
+
+  @Operation(summary = "이 주의 영화 정보 조회", description = "영화 정보만 반환됩니다.")
+  @GetMapping("/this-week/{movieId}")
+  public ResponseEntity<MovieDTO> getThisWeekMovieDetail(
+      @PathVariable Long movieId
+  ) {
+    MovieDTO movieDetails = movieService.getThisWeekMovieDetail(movieId);
     return ResponseEntity.ok(movieDetails);
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/movie/entity/Genre.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/entity/Genre.java
@@ -12,11 +12,13 @@ import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@BatchSize(size = 10)
 public class Genre {
 
   @Id

--- a/ddv/src/main/java/community/ddv/domain/movie/repostitory/MovieRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/repostitory/MovieRepository.java
@@ -25,9 +25,22 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
   List<Movie> findAllByAvailableIsTrueOrderByPopularityDesc(@Param("limit") int limit);
 
   // 특정 단어가 포함된 영화 정보 리스트 조회(공백 무시)
-  @EntityGraph(attributePaths = {"movieGenres.genre"})
-  @Query("SELECT m FROM Movie m WHERE REPLACE(m.title, ' ', '') LIKE CONCAT('%', REPLACE(:title, ' ', ''), '%') ORDER BY m.popularity DESC")
+  @Query("""
+      SELECT m
+      FROM Movie m
+      WHERE REPLACE(m.title, ' ', '') LIKE CONCAT('%', REPLACE(:title, ' ', ''), '%')
+      ORDER BY m.popularity DESC
+      """)
   Page<Movie> findByTitleFlexible(@Param("title") String title, Pageable pageable);
+
+  // 제목 자동완성 5개
+  @Query("""
+      SELECT m.title
+      FROM Movie m
+      WHERE REPLACE(m.title, ' ', '') LIKE CONCAT('%', REPLACE(:keyword, ' ', ''), '%')
+      ORDER BY m.popularity DESC
+""")
+      List<String> find5AutocompleteTitles(@Param("keyword") String title, Pageable pageable);
 
   // TMDB Id로 특정영화 조회
   Optional<Movie> findByTmdbId(Long tmdbId);

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -44,12 +44,12 @@ public class NotificationService {
    */
   public SseEmitter subscribe(Long userId) {
 
-    log.info("SSE 구독 시작 : userId = {}", userId);
+    //log.info("SSE 구독 시작 : userId = {}", userId);
 
     // 1. 기존 emitter 끊기
     SseEmitter previousEmitter = emitters.remove(userId);
     if (previousEmitter != null) {
-      log.info("기존 emitter 존재 -> 제거 완료 userId = {}", userId);
+      //log.info("기존 emitter 존재 -> 제거 완료 userId = {}", userId);
       previousEmitter.complete();
     }
 
@@ -88,11 +88,11 @@ public class NotificationService {
   //  SSE 초기 메시지 전송 메서드
   private void sendFirstMessage(Long userId, SseEmitter emitter) {
     try {
-      log.info("SSE 초기 메시지 전송 시도: userId = {}", userId);
+      //log.info("SSE 초기 메시지 전송 시도: userId = {}", userId);
       emitter.send(SseEmitter.event()
           .name("connect")
           .data("SSE connect success"));
-      log.info("SSE 초기 메시지 전송 완료");
+      //log.info("SSE 초기 메시지 전송 완료");
     } catch (IOException e) {
       log.error("SSE 초기 메시지 전송 실패: userId = {}, error = {}", userId, e.getMessage());
       emitter.completeWithError(e);


### PR DESCRIPTION
# [변경사항]

- EntityGraph(attributePaths = {"movieGenres.genre"})를 통해 Genre를 즉시 로딩(fetch join)했지만, 이를 제거하고 대신 Genre 엔티티에 @ BatchSize를 설정했습니다.

  - firstResult/maxResults specified with collection fetch; applying in memory 로그 발생 
    - @ EntityGraph를 통해 조회하면서 페이징을 사용하면  JPA는 중복된 row를 내보내기 때문에 전체 결과를 메모리로 불러온 뒤 중복을 제거하고 잘라내는 방식으로 처리하게 되어 메모리 페이징 경고가 생긴 것. 
  - 장르 엔티티에 @ BatchSize를 적용하여 N+1 문제를 줄이되 페이징은 DB에서 처리하도록 수정 

- review가 존재하지 않으면 null로 반환했으나, 반환형 통일을 위해 []로 내보내도록 재수정
- 이주의 영화의 영화 정보만 조회하는 경량화 된 API를 만들었습니다.  

