### PR TITLE
refactor : 영화 정보 조회시 리뷰 데이터를 반환하지 않도록 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
@@ -46,9 +46,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   Double findAverageRatingByMovie(@Param("movie") Movie movie);
 
   @Query("""
-          select r from Review r
-          join fetch r.user u
-          join fetch r.movie m
+          select distinct r from Review r
+          join fetch r.user
+          join fetch r.movie
           left join fetch r.comments c
           left join fetch c.user
           where r.id = :reviewId

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -188,6 +188,7 @@ public class ReviewService {
    */
   @Transactional(readOnly = true)
   public PageResponse<ReviewResponseDTO> getLatestReviews(Pageable pageable) {
+    //Page<Review> reviews = reviewRepository.findAllByOrderByCreatedAtDesc(pageable);
     Page<Review> reviews = reviewRepository.findLatestReviews(pageable);
     Page<ReviewResponseDTO> reviewResponseDTOS = reviews.map(this::convertToReviewResponseWithoutCommentsDto);
     return new PageResponse<>(reviewResponseDTOS);

--- a/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
@@ -27,7 +27,7 @@ public class MovieDTO {
   private List<Long> genre_ids;   // 장르 아이디 리스트
   private List<String> genre_names; // 장르 이름 리스트
 
-  private List<ReviewResponseDTO> reviews;
+  //private List<ReviewResponseDTO> reviews;
   private ReviewResponseDTO myReview;
   private ReviewRatingDTO ratingStats; // 별점 정보 (평균, 분포)
 

--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
@@ -45,7 +45,7 @@ public class MovieService {
     List<Movie> topMovies = movieRepository.findAllByAvailableIsTrueOrderByPopularityDesc(size);
     log.info("인기도 탑{} 영화 조회 성공", size);
     return topMovies.stream()
-        .map(movie -> convertToDto(movie, null, null, reviewService.getRatingsByMovie(movie)))
+        .map(movie -> convertToDto(movie, null, reviewService.getRatingsByMovie(movie)))
         .collect(Collectors.toList());
   }
 
@@ -83,7 +83,7 @@ public class MovieService {
     return movies
         .map(movie -> {
           ReviewRatingDTO ratingStats = reviewService.getRatingsByMovie(movie);
-          return convertToDto(movie, null, null, ratingStats);
+          return convertToDto(movie, null, ratingStats);
         });
   }
 
@@ -101,9 +101,9 @@ public class MovieService {
           return new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND);
         });
 
-    // 최신 리뷰 9개만 보여주기
-    Pageable pageable = PageRequest.of(0, 9, Sort.by(Direction.DESC, "createdAt"));
-    Page<ReviewResponseDTO> reviews = reviewService.getReviewByMovieId(tmdbId, pageable, certifiedFilter);
+//    // 최신 리뷰 9개만 보여주기
+//    Pageable pageable = PageRequest.of(0, 9, Sort.by(Direction.DESC, "createdAt"));
+//    Page<ReviewResponseDTO> reviews = reviewService.getReviewByMovieId(tmdbId, pageable, certifiedFilter);
 
     ReviewResponseDTO myReview = null;
     User loginUser = userService.getLoginOrNull();
@@ -113,7 +113,7 @@ public class MovieService {
     }
 
   //  log.info("영화 tmdbId = '{}'로 영화의 세부정보 조회 성공", tmdbId);
-    return convertToDto(movie, reviews.getContent(), myReview, reviewService.getRatingsByMovie(movie));
+    return convertToDto(movie, myReview, reviewService.getRatingsByMovie(movie));
   }
 
 
@@ -129,7 +129,7 @@ public class MovieService {
 
   public MovieDTO convertToDto(
       Movie movie,
-      List<ReviewResponseDTO> reviews,
+      //List<ReviewResponseDTO> reviews,
       ReviewResponseDTO myReview,
       ReviewRatingDTO ratingStats) {
 
@@ -149,7 +149,7 @@ public class MovieService {
         .genre_names(movie.getMovieGenres().stream()
             .map(movieGenre -> movieGenre.getGenre().getName())
             .collect(Collectors.toList()))
-        .reviews(reviews != null ? reviews : Collections.emptyList())
+        //.reviews(reviews != null ? reviews : Collections.emptyList())
         .myReview(myReview)
         .ratingStats(ratingStats)
         .isAvailable(movie.isAvailable())


### PR DESCRIPTION
# [변경사항]

- 단일책임원칙을 준수하기 위해 MovieDto에서 Reviews를 제외했습니다. 
  - 영화 정보 조회시, 관련 리뷰들은 더이상 조회되지 않습니다. 대신 특정 영화 리뷰 조회 API를 사용하면 됩니다. 
