### PR TITLE
refactor : 페이징처리 방식을 PageableDefault 애너테이션을 사용하는 것으로 통일, 특정 리뷰에 달린 댓글 조회 디폴트 정렬 방식을 오름차순으로 수정 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -69,7 +70,7 @@ public class CommentController {
   @GetMapping
   public ResponseEntity<PageResponse<CommentResponseDto>> getCommentsByReviewId(
       @PathVariable Long reviewId,
-      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+      @PageableDefault(size = 20, sort = "createdAt", direction = Direction.ASC) Pageable pageable) {
 
     Page<CommentResponseDto> comments = commentService.getCommentsByReviewId(reviewId, pageable);
     return ResponseEntity.ok(new PageResponse<>(comments));

--- a/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/ReviewController.java
@@ -64,24 +64,14 @@ public class ReviewController {
     return ResponseEntity.ok(reviewService.updateReview(reviewId, reviewUpdateDTO));
   }
 
-  @Operation(summary = "특정 영화에 대한 리뷰 조회", description = "댓글은 포함되어있지 않습니다. ?sortBy=likeCount로 좋아요 순 정렬을 할 수 있습니다." )
+  @Operation(summary = "특정 영화에 대한 리뷰 조회", description = "댓글은 포함되어있지 않습니다." )
   @GetMapping("/movie/{tmdbId}")
   public ResponseEntity<PageResponse<ReviewResponseDTO>> getReviewsByMovieId(
       @PathVariable Long tmdbId,
       @RequestParam(value = "certifiedFilter", required = false, defaultValue = "false") Boolean certifiedFilter,
-      @PageableDefault(size = 20) Pageable pageable,
-      @RequestParam(value = "sortBy", required = false, defaultValue = "createdAt") String sortBy,
-      @RequestParam(value = "direction", required = false, defaultValue = "DESC") Direction direction
+      @PageableDefault(size = 20, sort = "createdAt", direction = Direction.DESC) Pageable pageable
   ) {
-
-    Sort sort = "likeCount".equals(sortBy)
-      // 좋아요순으로 정렬 시 동점일 경우 최신순 정렬
-      ? Sort.by(Sort.Order.by("likeCount").with(direction))
-            .and(Sort.by(Sort.Order.by("createdAt").with(direction)))
-      : Sort.by(Sort.Order.by("createdAt").with(direction));
-
-    Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
-    Page<ReviewResponseDTO> reviews = reviewService.getReviewByMovieId(tmdbId, sortedPageable, certifiedFilter);
+    Page<ReviewResponseDTO> reviews = reviewService.getReviewByMovieId(tmdbId, pageable, certifiedFilter);
     return ResponseEntity.ok(new PageResponse<>(reviews));
   }
 
@@ -95,11 +85,8 @@ public class ReviewController {
   @Operation(summary = "최신 리뷰 조회", description = "디폴트 사이즈는 9입니다.")
   @GetMapping("/latest")
   public ResponseEntity<PageResponse<ReviewResponseDTO>> getLatestReviews(
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "9") int size
+      @PageableDefault(size = 9, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
   ) {
-    Sort sortOrder = Sort.by(Sort.Order.desc("createdAt"));
-    Pageable pageable = PageRequest.of(page, size, sortOrder);
     PageResponse<ReviewResponseDTO> response = reviewService.getLatestReviews(pageable);
     return ResponseEntity.ok(response);
   }

--- a/ddv/src/main/java/community/ddv/domain/board/service/DiscussionService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/DiscussionService.java
@@ -64,22 +64,23 @@ public class DiscussionService {
     log.info("리뷰 작성 가능 기간 확인 완료");
 
     // 4. 중복 리뷰 확인 -> 기존에 작성한 리뷰가 있으면 수정
-    Review existingReview = reviewRepository.findByUserAndMovie(user, lastWeekTopMovie)
-        .orElse(null);
-
-    if (existingReview != null) {
-      log.info("기존에 작성한 리뷰가 있으므로 수정 시도 : reviewId = {}", existingReview.getId());
-      ReviewUpdateDTO updateDTO = new ReviewUpdateDTO(
-          reviewDTO.getTitle(),
-          reviewDTO.getContent(),
-          reviewDTO.getRating());
-
-      ReviewResponseDTO updatedReview = reviewService.updateReview(existingReview.getId(), updateDTO);
-      existingReview.updateCertified(true); // 인증 마크 달기
-      reviewRepository.save(existingReview);
-      log.info("기존리뷰 수정완료 : reviewId = {}", existingReview.getId());
-      return updatedReview;
-    }
+    // (사용하지 않는 것으로 수정. 봤던 영화를 또 다시 보고 인증 받고 리뷰를 다시 작성하는 경우가 많이 없을 것으로 판단)
+//    Review existingReview = reviewRepository.findByUserAndMovie(user, lastWeekTopMovie)
+//        .orElse(null);
+//
+//    if (existingReview != null) {
+//      log.info("기존에 작성한 리뷰가 있으므로 수정 시도 : reviewId = {}", existingReview.getId());
+//      ReviewUpdateDTO updateDTO = new ReviewUpdateDTO(
+//          reviewDTO.getTitle(),
+//          reviewDTO.getContent(),
+//          reviewDTO.getRating());
+//
+//      ReviewResponseDTO updatedReview = reviewService.updateReview(existingReview.getId(), updateDTO);
+//      existingReview.updateCertified(true); // 인증 마크 달기
+//      reviewRepository.save(existingReview);
+//      log.info("기존리뷰 수정완료 : reviewId = {}", existingReview.getId());
+//      return updatedReview;
+//    }
 
     // 5. 새 리뷰 생성, 저장
     ReviewDTO newReview = ReviewDTO.builder()


### PR DESCRIPTION
# [변경사항]

1. 기존에 리뷰를 작성했던 경우, 인증 받고 리뷰를 수정하는 로직 삭제
  - 봤던 영화를 다시 보고 인증까지 받고 리뷰를 다시 작성하는 경우가 많이 없을 것으로 판단. 
  만약 리뷰에 인증 뱃지를 달고 싶다면 기존 리뷰 삭제 후 인증 받고 리뷰를 새로 작성하도록 수정
  
2. 기존에 page와 size를 직접 파라미터로 받아서 PageRequest를 생성하던 방식을 @ PageableDefault 어노테이션을 활용해 페이징 처리 방식을 통일하고 간결하게 개선했습니다.

3. /api/reviews/{reviewId}/comments 특정 리뷰에 달린 댓글 조회 디폴트 정렬 방식을 오름차순으로 수정했습니다. 