### PR TITLE
refactor : 리뷰 정렬에 likeCount 사용 시 createdAt을 보조 정렬 기준으로 추가

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
@@ -1,8 +1,8 @@
 package community.ddv.domain.board.controller;
 
+import community.ddv.domain.board.dto.CommentDTO;
 import community.ddv.domain.board.dto.CommentDTO.CommentResponseDto;
 import community.ddv.domain.board.service.CommentService;
-import community.ddv.domain.board.dto.CommentDTO;
 import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,7 +10,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -26,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/ddv/src/main/java/community/ddv/domain/movie/controller/MovieController.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/controller/MovieController.java
@@ -9,7 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,7 +38,7 @@ public class MovieController {
   @GetMapping("/search/list")
   public ResponseEntity<PageResponse<MovieDTO>> getMoviesByTitle(
       @RequestParam("title") String title,
-      @PageableDefault(size = 10, sort = "popularity", direction = Sort.Direction.DESC) Pageable pageable
+      @PageableDefault(size = 10, sort = "popularity", direction = Direction.DESC) Pageable pageable
       ) {
     Page<MovieDTO> movies = movieService.searchMoviesByTitle(title, pageable);
     return ResponseEntity.ok(new PageResponse<>(movies));

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -39,7 +38,7 @@ public class NotificationController {
   @Operation(summary = "알림 목록 조회")
   @GetMapping
   public ResponseEntity<PageResponse<NotificationResponseDTO>> getNotifications(
-      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+      @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
     PageResponse<NotificationResponseDTO> notifications = notificationService.getNotifications(pageable);
     return ResponseEntity.ok(notifications);
   }


### PR DESCRIPTION
# [변경사항]

- 수정 전 
  - `page`, `size` 파라미터를 수동으로 지정했던 방식 -> `Pageable`을 사용하여 Spring이 자동으로 `page`, `size`, `sort` 파라미터를 바인딩하도록 수정
  - 좋아요수 내림차순 정렬(?sort=likeCount,desc)시, 그 수가 동수인 경우 리뷰가 작성된 오름차순으로 조회되는 문제 발생
  - 좋아요 수 내림차순 정렬 후 최신순 정렬을 적용하기 위해서는 
  ?sort=likeCount&sort=createdAt으로 정렬 기준을 2개를 모두 명시해야 함
  - FE 측에서 정렬 기준을 하나로 통일해 달라는 요청이 있었음 
 
- 수정 후
  - likeCount를 정렬 기준으로 사용하는 경우, 보조 정렬 조건으로 createdAt, desc가 자동으로 추가되도록 수정했습니다. 
  -  ?sort=likeCount,desc로만 요청해도?sort=likeCount,desc&sort=createdAt,desc처럼 동작하여 정렬 일관성이 보장됩니다. 