### PR TITLE
refactor : TMDB에서 영화 데이터를 API 콜하여 가져오는 코드 효율적으로 수정 & feat : 투표 선택지 선정 방법 변경 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/board/repository/ReviewRepository.java
@@ -29,7 +29,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
   List<Review> findAllByUser_Id(Long userId);
 
-  //Page<Review> findAllByOrderByCreatedAtDesc(Pageable pageable);
+  // 최신 리뷰 조회
   @Query(
       value = """
             select r from Review r
@@ -45,6 +45,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   @Query("select avg(r.rating) from Review r where r.movie = :movie")
   Double findAverageRatingByMovie(@Param("movie") Movie movie);
 
+  // 특정 리뷰 조회 (댓글도 함께 조회)
   @Query("""
           select distinct r from Review r
           join fetch r.user

--- a/ddv/src/main/java/community/ddv/domain/movie/repostitory/MovieRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/repostitory/MovieRepository.java
@@ -3,6 +3,7 @@ package community.ddv.domain.movie.repostitory;
 import community.ddv.domain.movie.entity.Movie;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -44,5 +45,13 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
 
   // TMDB Id로 특정영화 조회
   Optional<Movie> findByTmdbId(Long tmdbId);
+
+  @Query("""
+      SELECT m 
+      FROM Movie m 
+      WHERE m.tmdbId NOT IN :excludedTmdbIds 
+      ORDER BY m.popularity DESC
+      """)
+  List<Movie> findTop6RankExcludedTmdbIds(Set<Long> excludedTmdbIds, Pageable pageable);
 
 }

--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
@@ -12,7 +12,6 @@ import community.ddv.domain.user.entity.User;
 import community.ddv.domain.user.service.UserService;
 import community.ddv.global.exception.DeepdiviewException;
 import community.ddv.global.exception.ErrorCode;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -22,8 +21,6 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,11 +56,11 @@ public class MovieService {
   }
 
   /**
-   * 넷플릭스 내 인기도 탑 5 영화 세부정보 조회
+   * 넷플릭스 내 인기도 탑 6 영화 세부정보 조회
    */
   @Transactional(readOnly = true)
-  public List<MovieDTO> getTop5Movies() {
-    return getTopMovies(5);
+  public List<MovieDTO> getTop6Movies() {
+    return getTopMovies(6);
   }
 
   /**

--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieService.java
@@ -55,13 +55,13 @@ public class MovieService {
     return getTopMovies(20);
   }
 
-  /**
-   * 넷플릭스 내 인기도 탑 6 영화 세부정보 조회
-   */
-  @Transactional(readOnly = true)
-  public List<MovieDTO> getTop6Movies() {
-    return getTopMovies(6);
-  }
+//  /**
+//   * 넷플릭스 내 인기도 탑 6 영화 세부정보 조회
+//   */
+//  @Transactional(readOnly = true)
+//  public List<MovieDTO> getTop6Movies() {
+//    return getTopMovies(6);
+//  }
 
   /**
    * 키워드로 영화 검색 _ 공백 무시 가능 & 특정 글자가 포함되는 조회됨 & 넷플 인기도 순 정렬

--- a/ddv/src/main/java/community/ddv/domain/vote/service/VoteService.java
+++ b/ddv/src/main/java/community/ddv/domain/vote/service/VoteService.java
@@ -94,8 +94,8 @@ public class VoteService {
 //    LocalDateTime startDate = thisWeekStart;
 //    LocalDateTime endDate = thisWeekEnd;
 
-    // 인기도 탑 5의 영화 세부 정보 가져오기
-    List<MovieDTO> top5Movies = movieService.getTop5Movies();
+    // 인기도 탑 6의 영화 세부 정보 가져오기
+    List<MovieDTO> top6Movies = movieService.getTop6Movies();
     log.info("인기도 탑5의 영화를 가져왔습니다.");
 
     Vote vote = Vote.builder()
@@ -106,7 +106,7 @@ public class VoteService {
         .build();
 
     // 선택된 영화들을 VoteMovie 테이블에 저장
-    for (MovieDTO movieDTO : top5Movies) {
+    for (MovieDTO movieDTO : top6Movies) {
       Movie movie = movieRepository.findByTmdbId(movieDTO.getId())
           .orElseThrow(() -> new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND));
       VoteMovie voteMovie = VoteMovie.builder()

--- a/ddv/src/main/java/community/ddv/domain/vote/service/VoteService.java
+++ b/ddv/src/main/java/community/ddv/domain/vote/service/VoteService.java
@@ -27,11 +27,15 @@ import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -94,9 +98,11 @@ public class VoteService {
 //    LocalDateTime startDate = thisWeekStart;
 //    LocalDateTime endDate = thisWeekEnd;
 
-    // 인기도 탑 6의 영화 세부 정보 가져오기
-    List<MovieDTO> top6Movies = movieService.getTop6Movies();
-    log.info("인기도 탑5의 영화를 가져왔습니다.");
+    // 과거에 1위를 했던 영화들 가져오기
+    Set<Long> pastTopMovies = getAllPastTopRankMovies();
+    // 과거 1위 했던 영화 빼고 인기도 탑 6개 가져오기
+    Pageable topMoviesSize = PageRequest.of(0, 6);
+    List<Movie> top6Movies = movieRepository.findTop6RankExcludedTmdbIds(pastTopMovies, topMoviesSize);
 
     Vote vote = Vote.builder()
         .title("다음주의 영화를 선택해주세요")
@@ -106,9 +112,7 @@ public class VoteService {
         .build();
 
     // 선택된 영화들을 VoteMovie 테이블에 저장
-    for (MovieDTO movieDTO : top6Movies) {
-      Movie movie = movieRepository.findByTmdbId(movieDTO.getId())
-          .orElseThrow(() -> new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND));
+    for (Movie movie : top6Movies) {
       VoteMovie voteMovie = VoteMovie.builder()
           .vote(vote)
           .movie(movie)
@@ -121,6 +125,20 @@ public class VoteService {
     return new VoteCreatedDTO(savedVote);
 
   }
+
+  // 과거 투표 1위했던 영화 조회 메서드
+  public Set<Long> getAllPastTopRankMovies() {
+    List<Vote> allVotes = voteRepository.findAll();
+    Set<Long> topTmdbIds = new HashSet<>();
+    for (Vote vote : allVotes) {
+      List<VoteMovieResultDTO> resultDTOS = calculateVoteResult(vote);
+      if (!resultDTOS.isEmpty()) {
+        topTmdbIds.add(resultDTOS.get(0).getTmdbId());
+      }
+    }
+    return topTmdbIds;
+  }
+
 
   /**
    * 현재 진행중인 투표의 선택지 조회 tmdbIds 반환

--- a/ddv/src/main/java/community/ddv/global/component/Scheduler.java
+++ b/ddv/src/main/java/community/ddv/global/component/Scheduler.java
@@ -18,21 +18,13 @@ public class Scheduler {
   private final CacheManager cacheManager;
   private final CertificationService certificationService;
 
-  // 매주 월요일 0시 0분 0초에 영화 데이터 업데이트하면서 인기 영화 목록 캐시 초기화
-  @Scheduled(cron = "0 0 0 * * MON")
+  // 매주 일요일 0시 0분 5초에 영화 데이터 업데이트하면서 인기 영화 목록 캐시 초기화
+  @Scheduled(cron = "5 0 0 * * SUN")
   public void updateMovieApi() {
     log.info("영화정보 업데이트를 시작합니다.");
     movieApiService.fetchAndSaveMovies();
     log.info("영화정보 업데이트를 완료했습니다.");
     clearTopMoviesCache();
-  }
-
-  // 매주 월요일 0시 5분에 런타임 데이터 업데이트
-  @Scheduled(cron = "0 5 0 * * MON")
-  public void updateMovieRuntimeApi() {
-    log.info("런타임정보 업데이트를 시작합니다.");
-    movieApiService.fetchMovieRunTime();
-    log.info("런타임정보 업데이트를 완료했습니다.");
   }
 
   public void clearTopMoviesCache() {
@@ -43,7 +35,15 @@ public class Scheduler {
     log.info("인기영화 캐시 초기화 완료");
   }
 
-  // 지난 주 1위 영화 캐시 초기화
+  // 매주 일요일 0시 2분에 런타임 데이터 업데이트
+  @Scheduled(cron = "0 2 0 * * SUN")
+  public void updateMovieRuntimeApi() {
+    log.info("런타임정보 업데이트를 시작합니다.");
+    movieApiService.fetchMovieRunTime();
+    log.info("런타임정보 업데이트를 완료했습니다.");
+  }
+
+  // 매주 일요일 0시 0분 0초 지난 주 1위 영화 캐시 초기화
   @Scheduled(cron = "0 0 0 * * SUN")
   public void clearTopRankMovieCache() {
     Cache topVotedCache = cacheManager.getCache("topRankMovie");
@@ -54,8 +54,8 @@ public class Scheduler {
     log.info("지난 주 1위 영화 캐시 초기화 완료");
   }
 
-  // 매주 일요일 0시, 인증상태 초기화 스케줄링
-  @Scheduled(cron = "0 0 0 * * SUN")
+  // 매주 일요일 0시 2초, 인증상태 초기화 스케줄링
+  @Scheduled(cron = "2 0 0 * * SUN")
   public void resetCertificationStatus() {
     certificationService.resetCertificationStatus();
   }


### PR DESCRIPTION
# [변경사항]

- TMDB API에서 영화 데이터를 가져올 때, 반복문 내에서 쿼리를 실행하던 코드를 반복문 밖으로 이동하여 한 번만 조회하도록 수정했습니다.
  - 이로 인해 처리 시간이 4분 이상에서 2분 이하로 단축되었습니다.
  
- 스케줄링 시간을 변경했습니다. 
  - 일요일에 스케줄링 한 인기 20위 영화를 바탕으로 투표를 만들도록 변경 
 
- 투표 선택지 개수를 5개 -> 6개로 변경했습니다. 
- 과거에 투표 1위를 했던 영화는 새로운 투표의 선택지에 들어올 수 없도록 변경했습니다. 