### PR TITLE
feat : 투표 생성시 tmdbId들만 나오도록 수정 & 투표 선택지 조회는 언제든지 가능하도록 수정 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
@@ -69,7 +69,7 @@ public class CommentController {
   @GetMapping
   public ResponseEntity<PageResponse<CommentResponseDto>> getCommentsByReviewId(
       @PathVariable Long reviewId,
-      @PageableDefault(size = 20, sort = "createdAt", direction = Direction.ASC) Pageable pageable) {
+      @PageableDefault(size = 20, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
 
     Page<CommentResponseDto> comments = commentService.getCommentsByReviewId(reviewId, pageable);
     return ResponseEntity.ok(new PageResponse<>(comments));

--- a/ddv/src/main/java/community/ddv/domain/vote/controller/VoteController.java
+++ b/ddv/src/main/java/community/ddv/domain/vote/controller/VoteController.java
@@ -33,9 +33,9 @@ public class VoteController {
 
   @Operation(summary = "투표 생성", description = "관리자 전용, 일요일만 투표 생성 가능")
   @PostMapping
-  public ResponseEntity<VoteCreatedDTO> createVote() {
-    VoteCreatedDTO responseDTO = voteService.createVote();
-    return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+  public ResponseEntity<VoteOptionsDto> createVote() {
+    VoteOptionsDto voteCreateDtos = voteService.createVote();
+    return ResponseEntity.status(HttpStatus.CREATED).body(voteCreateDtos);
   }
 
   @Operation(summary = "현재 진행중인 투표의 선택지 조회", description = "현재 투표가 진행중일 때만 조회 가능합니다.")

--- a/ddv/src/main/java/community/ddv/domain/vote/repository/VoteRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/vote/repository/VoteRepository.java
@@ -13,6 +13,9 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
   // 투표가 진행중인지 확인 (시작일이 현재보다 먼저여야 하고, 마감일이 현재 이후여야 함
   Optional<Vote> findByStartDateBeforeAndEndDateAfter(LocalDateTime start, LocalDateTime end);
 
+  // 가장 가까운 미래의 투표 조회
+  Optional<Vote> findFirstByStartDateAfterOrderByStartDateAsc(LocalDateTime start);
+
   // 이번주에 생성된 투표가 있는지 여부
   boolean existsByStartDateBetween(LocalDateTime weekStart, LocalDateTime weekEnd);
 

--- a/ddv/src/main/java/community/ddv/domain/vote/service/VoteService.java
+++ b/ddv/src/main/java/community/ddv/domain/vote/service/VoteService.java
@@ -54,7 +54,7 @@ public class VoteService {
    * 투표 종료일 : 해당 주 토요일 23시 59분 59초
    */
   @Transactional
-  public VoteCreatedDTO createVote() {
+  public VoteOptionsDto createVote() {
 
     // 로그인된 관리자만 투표 생성 가능
     User admin = userService.getLoginUser();
@@ -66,7 +66,6 @@ public class VoteService {
 
     // 투표 생성은 일요일만 가능, 한 주에 한 번만 가능
     LocalDateTime now = LocalDateTime.now();
-
     if (now.getDayOfWeek() != DayOfWeek.SUNDAY) {
       log.error("투표 생성은 일요일만 가능합니다 : 현재요일 = {}", now.getDayOfWeek());
       throw new DeepdiviewException(ErrorCode.INVALID_VOTE_CREATE_DATE);
@@ -119,8 +118,11 @@ public class VoteService {
     }
     Vote savedVote = voteRepository.save(vote);
 
+    List<Long> tmdbIds = savedVote.getVoteMovies().stream()
+        .map(voteMovie -> voteMovie.getMovie().getTmdbId())
+        .toList();
     log.info("투표 생성 완료 : voteId = {}, 시작시간 = {}, 종료시간 = {}", savedVote.getId(), savedVote.getStartDate(), savedVote.getEndDate());
-    return new VoteCreatedDTO(savedVote);
+    return new VoteOptionsDto(tmdbIds);
 
   }
 


### PR DESCRIPTION
# [변경사항]

- 투표 생성시 GET /api/votes/options 와 동일하게 투표 선택지들의 tmdbId 들만 조회되도록 수정 
- 투표 선택지 조회 요일 제한 제거 
  -  수정 전 : 일요일에는 선택지 조회 불가.
  - 수정 후 : 일요일에도 선택지 조회 가능하도록 수정. 투표가 만들어지지 않았을 시, 빈 리스트로 반환
- 댓글 조회시 내림차순으로 정렬되도록 수정 