### PR TITLE
feat : 특정 리뷰에 대한 댓글 조회시, 커서기반 페이징처리하도록 수정

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
+++ b/ddv/src/main/java/community/ddv/domain/board/controller/CommentController.java
@@ -3,15 +3,12 @@ package community.ddv.domain.board.controller;
 import community.ddv.domain.board.dto.CommentDTO;
 import community.ddv.domain.board.dto.CommentDTO.CommentResponseDto;
 import community.ddv.domain.board.service.CommentService;
-import community.ddv.global.response.PageResponse;
+import community.ddv.global.response.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort.Direction;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -21,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -67,11 +65,13 @@ public class CommentController {
 
   @Operation(summary = "특정 리뷰에 달린 댓글 조회")
   @GetMapping
-  public ResponseEntity<PageResponse<CommentResponseDto>> getCommentsByReviewId(
+  public ResponseEntity<CursorPageResponse<CommentResponseDto>> getCommentsByReviewId(
       @PathVariable Long reviewId,
-      @PageableDefault(size = 20, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
-
-    Page<CommentResponseDto> comments = commentService.getCommentsByReviewId(reviewId, pageable);
-    return ResponseEntity.ok(new PageResponse<>(comments));
+      @RequestParam(required = false) LocalDateTime createdAt,
+      @RequestParam(required = false) Long commentId,
+      @RequestParam(defaultValue = "20") int size) {
+    CursorPageResponse<CommentResponseDto> response =
+        commentService.getCommentsByReviewId(reviewId, createdAt, commentId, size);
+    return ResponseEntity.ok(response);
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/board/repository/CommentRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/board/repository/CommentRepository.java
@@ -2,9 +2,13 @@ package community.ddv.domain.board.repository;
 
 import community.ddv.domain.board.entity.Comment;
 import community.ddv.domain.board.entity.Review;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,7 +19,26 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
   int countByReview(Review review);
 
   // 특정 리뷰에 달린 댓글 조회
-  Page<Comment> findByReview(Review review, Pageable pageable);
+  //Page<Comment> findByReview(Review review, Pageable pageable);
+
+  // 커서 없는 첫 페이지
+  List<Comment> findByReviewOrderByCreatedAtDescIdDesc(Review review, Pageable pageable);
+
+  // 주어진 커서 (createdAt, id) 이전의 댓글들만 조회
+  @Query("""
+    SELECT c
+    FROM Comment c
+    WHERE c.review = :review
+      AND ((c.createdAt < :createdAt) OR (c.createdAt = :createdAt AND c.id < :id))
+    ORDER BY c.createdAt DESC, c.id DESC
+  """)
+  List<Comment> findCommentsByReviewBeforeCursor(
+      @Param("review") Review review,
+      @Param("createdAt") LocalDateTime createdAt,
+      @Param("id") Long id,
+      Pageable pageable
+  );
+
 
   // 특정 사용자가 작성한 댓글 조회
   Page<Comment> findByUser_Id(Long userId, Pageable pageable);

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -227,8 +227,10 @@ public class CertificationService {
       certifications = certificationRepository.findByStatusWithCursor(status,cursorCreatedAt, cursorId, pageable);
     }
 
-    // 다음 커서 계산
+    // 다음 페이지 존재 여부 판단
     boolean hasNext = certifications.size() == size;
+
+    // 다음 요청을 위한 커서 값 준비
     LocalDateTime nextCreatedAt = null;
     Long nextCertificationId = null;
 

--- a/ddv/src/main/java/community/ddv/global/response/CursorPageResponse.java
+++ b/ddv/src/main/java/community/ddv/global/response/CursorPageResponse.java
@@ -10,8 +10,8 @@ import lombok.Getter;
 public class CursorPageResponse<T> {
 
   private List<T> content; // 데이터들
-  private LocalDateTime nextCreatedAt; // 마지막 인증의 생성시간
-  private Long nextCertificationId; // 마지막 인증의 ID
+  private LocalDateTime nextCreatedAt; // 마지막 생성시간
+  private Long nextId; // 마지막 ID
   private boolean hasNext; // 더 많은 데이터가 있는지 여부
 
 }


### PR DESCRIPTION
# [변경사항]

1. 처음 요청시에는 파라미터를 적지 않아도 됩니다. 
    - 최신순으로 기본 20개 정렬이 됩니다 (default size = 20으로 설정해두었습니다. )
2. 마지막에 조회한 데이터 정보 
     `"nextCreatedAt"`  
     `"nextId"` 
     이 두 개를 응답 받으면 `"hasNext"`: `false` 가 될 때까지 두 가지 정보를 모두 쿼리 파라미터로 넣어야 합니다. 