### PR TITLE
fix : LastModifiedDate를 썼음에도 updatedAt이 바로 업데이트 되지 않는 이슈 해결 & refactor : TMDB에서 데이터를 받아올 때 장르정보 저장 반복 제거 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/service/CommentService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/CommentService.java
@@ -76,6 +76,7 @@ public class CommentService {
     }
 
     comment.updateContent(commentRequestDto.getContent());
+    commentRepository.flush();
 
     return convertToCommentResponse(comment);
   }

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationRepository.java
@@ -39,6 +39,9 @@ public interface CertificationRepository extends JpaRepository<Certification, Lo
     Pageable pageable
   );
 
+  @Query(value = "SELECT certificationUrl FROM certification", nativeQuery = true)
+  List<String> findAllCertificationUrls();
+
   // ENUM 타입을 NULL로 초기화 하기 위해 네이티브쿼리 사용
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = "UPDATE certification SET status = NULL, rejection_reason = NULL", nativeQuery = true)

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -316,11 +316,12 @@ public class CertificationService {
     }
 
     // S3에서 파일 삭제
-    for (Certification certification : certifications) {
+    List<String> urls = certificationRepository.findAllCertificationUrls();
+    for (String certificationUrl : urls) {
       try {
-        fileStorageService.deleteFile(certification.getCertificationUrl());
+        fileStorageService.deleteFile(certificationUrl);
       } catch (RuntimeException e) {
-        log.info("인증샷 파일을 S3에서 삭제 실패 : url = {}", certification.getCertificationUrl());
+        log.info("인증샷 파일을 S3에서 삭제 실패 : url = {}", certificationUrl);
       }
     }
 


### PR DESCRIPTION
# [변경사항]

- 댓글 수정 시 updatedAt 필드가 DB에는 반영되지만, API 응답에는 즉시 반영되지 않는 문제를 해결했습니다.
  - commentRepository.flush()를 사용하여 변경 내용을 즉시 DB에 반영하고, 최신 updatedAt 값을 반환하도록 개선했습니다.

- 장르 데이터를 미리 Map에 두어 반복문 밖으로 빼내었습니다.
- API 콜을 해올 때 do-while -> while문을 사용하여 가독성 좋게 수정했습니다. 
