### PR TITLE
fix: 리뷰 API 응답에 타임존 오프셋(+09:00)을 추가하여 시간 일관성 보장

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/dto/ReviewResponseDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/board/dto/ReviewResponseDTO.java
@@ -2,6 +2,7 @@ package community.ddv.domain.board.dto;
 
 import community.ddv.domain.board.dto.CommentDTO.CommentResponseDto;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,8 +22,8 @@ public class ReviewResponseDTO {
   private String reviewTitle;
   private String reviewContent;
   private Double rating;
-  private LocalDateTime createdAt;
-  private LocalDateTime updatedAt;
+  private OffsetDateTime createdAt;
+  private OffsetDateTime updatedAt;
   private Integer commentCount;
   private Integer likeCount;
   private Boolean likedByUser;

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -15,6 +15,8 @@ import community.ddv.domain.user.service.UserService;
 import community.ddv.global.exception.DeepdiviewException;
 import community.ddv.global.exception.ErrorCode;
 import community.ddv.global.response.PageResponse;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -244,8 +246,8 @@ public class ReviewService {
         .reviewTitle(review.getTitle())
         .reviewContent(review.getContent())
         .rating(review.getRating())
-        .createdAt(review.getCreatedAt())
-        .updatedAt(review.getUpdatedAt())
+        .createdAt(review.getCreatedAt().atOffset(ZoneOffset.of("+09:00")))
+        .updatedAt(review.getUpdatedAt().atOffset(ZoneOffset.of("+09:00")))
         .commentCount(commentCount)
         .likeCount(review.getLikeCount())
         .likedByUser(likedByUser)


### PR DESCRIPTION
# [변경사항]

- 문제 상황 
  - 리뷰 상세 페이지 조회 시, 업로드된 실제 시간과 9시간 차이 발생 
  - 방금 업로드한 리뷰가 ‘9시간 후’로 표시되는 현상 발생

- 발생 이유
  - LocalDateTime은 타임존 정보를 포함하지 않아, FE에서 UTC와 KST가 혼용되어 9시간 차이 발생

- 문제 해결 
  - ReviewResponseDTO의 createdAt, updatedAt 필드에 KST(+09:00) 타임존 정보를 포함하도록 변경