### PR TITLE
feat : 회원정보 조회시 평균 별점도 함께 조회되도록 추가

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -200,7 +200,7 @@ public class ReviewService {
 
     // 평균 별점
     Double ratingAverage = reviewRepository.findAverageRatingByMovie(movie);
-    double roundedRatingAverage = ratingAverage == null ? 0.0 : Math.round(ratingAverage * 100) / 100.0;
+    double roundedRatingAverage = ratingAverage == null ? 0.0 : Math.round(ratingAverage * 10.0) / 10.0;
 
     // 별점 분포
     List<Review> reviews = reviewRepository.findByMovie(movie);

--- a/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/dto/MovieDTO.java
@@ -27,7 +27,6 @@ public class MovieDTO {
   private List<Long> genre_ids;   // 장르 아이디 리스트
   private List<String> genre_names; // 장르 이름 리스트
 
-  //private List<ReviewResponseDTO> reviews;
   private ReviewResponseDTO myReview;
   private ReviewRatingDTO ratingStats; // 별점 정보 (평균, 분포)
 

--- a/ddv/src/main/java/community/ddv/domain/user/dto/UserInfoDto.java
+++ b/ddv/src/main/java/community/ddv/domain/user/dto/UserInfoDto.java
@@ -1,5 +1,6 @@
 package community.ddv.domain.user.dto;
 
+import community.ddv.domain.board.dto.ReviewRatingDTO;
 import community.ddv.domain.certification.constant.CertificationStatus;
 import community.ddv.domain.certification.constant.RejectionReason;
 import jakarta.validation.constraints.NotBlank;
@@ -70,7 +71,7 @@ public class UserInfoDto {
     private String oneLineIntro;
     private int reviewCount; // 리뷰 작성 개수
     private int commentCount; // 댓글 작성 개수
-    private Map<Double, Long> ratingDistribution; // 별점 분포
+    private ReviewRatingDTO ratingStats; // 별점 분포, 평균 별점
     private CertificationStatus certificationStatus; // 인증 상태
     private RejectionReason rejectionReason; // 인증 거절 사유
   }


### PR DESCRIPTION
# [변경사항]

-  회원정보 조회 시, 별점 분포와 함께 평균별점도 조회되도록 추가했습니다. 
  - 영화 정보 조회 때와 마찬가지로 반환됩니다.

  >   "ratingStats": {
    "ratingAverage": 0.1,
    "ratingDistribution": {
      "0.0": 0,
      ~
      "5.0": 0,
    }
   
- 평균은 소수점 둘째자리에서 반올림하여 첫째자리까지만 보여주도록 했습니다. 
