### PR TITLE
feat : 리뷰, 댓글에 욕설 필터링 기능 추가 & feat : 이메일 인증코드 전송 기능 추가 

### DIFF
--- a/ddv/build.gradle
+++ b/ddv/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/ddv/src/main/java/community/ddv/domain/board/service/CommentService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/CommentService.java
@@ -28,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommentService {
 
   private final UserService userService;
+  private final forbiddenWordsFilter forbiddenWordsFilter;
   private final CommentRepository commentRepository;
   private final ReviewRepository reviewRepository;
   private final NotificationService notificationService;
@@ -42,10 +43,12 @@ public class CommentService {
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
     log.info("댓글이 달릴 reviewId: {}", review.getId());
 
+    String filteredContent = forbiddenWordsFilter.filterForbiddenWords(commentRequestDto.getContent());
+
     Comment comment = Comment.builder()
         .review(review)
         .user(user)
-        .content(commentRequestDto.getContent())
+        .content(filteredContent)
         .build();
 
     Comment newComment = commentRepository.save(comment);
@@ -75,7 +78,10 @@ public class CommentService {
       throw new DeepdiviewException(ErrorCode.INVALID_USER);
     }
 
-    comment.updateContent(commentRequestDto.getContent());
+    String filteredContent = forbiddenWordsFilter.filterForbiddenWords(commentRequestDto.getContent());
+
+
+    comment.updateContent(filteredContent);
     commentRepository.flush();
 
     return convertToCommentResponse(comment);

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -35,6 +35,7 @@ public class ReviewService {
   private final ReviewRepository reviewRepository;
   private final MovieRepository movieRepository;
   private final UserService userService;
+  private final forbiddenWordsFilter forbiddenWordsFilter;
   private final CommentRepository commentRepository;
   private final LikeRepository likeRepository;
 
@@ -55,12 +56,15 @@ public class ReviewService {
       throw new DeepdiviewException(ErrorCode.ALREADY_COMMITTED_REVIEW);
     }
 
+    String filteredTitle = forbiddenWordsFilter.filterForbiddenWords(reviewDTO.getTitle());
+    String filteredContent = forbiddenWordsFilter.filterForbiddenWords(reviewDTO.getContent());
+
     Review review = Review.builder()
         .user(user)
         .movie(movie)
         .tmdbId(movie.getTmdbId())
-        .title(reviewDTO.getTitle())
-        .content(reviewDTO.getContent())
+        .title(filteredTitle)
+        .content(filteredContent)
         .rating(reviewDTO.getRating())
         .likeCount(0)
         .certified(reviewDTO.isCertified())
@@ -109,9 +113,12 @@ public class ReviewService {
       throw new DeepdiviewException(ErrorCode.INVALID_USER);
     }
 
+    String filteredTitle = forbiddenWordsFilter.filterForbiddenWords(reviewUpdateDTO.getTitle());
+    String filteredContent = forbiddenWordsFilter.filterForbiddenWords(reviewUpdateDTO.getContent());
+
     review.updateReview(
-        reviewUpdateDTO.getTitle(),
-        reviewUpdateDTO.getContent(),
+        filteredTitle,
+        filteredContent,
         reviewUpdateDTO.getRating()
     );
 

--- a/ddv/src/main/java/community/ddv/domain/board/service/forbiddenWordsFilter.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/forbiddenWordsFilter.java
@@ -1,23 +1,18 @@
 package community.ddv.domain.board.service;
 
 import java.util.Set;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class forbiddenWordsFilter {
 
-  private final RedisTemplate<String, String> redisTemplate;
-
-  public forbiddenWordsFilter(@Qualifier("redisForbiddenWordsTemplate") RedisTemplate<String, String> redisTemplate) {
-    this.redisTemplate = redisTemplate;
-  }
+  private final RedisTemplate<String, String> redisStringTemplate;
 
   public Set<String> getForbiddenWords() {
-    return redisTemplate.opsForSet().members("forbidden-words");
+    return redisStringTemplate.opsForSet().members("forbidden-words");
   }
 
   public String filterForbiddenWords(String input) {

--- a/ddv/src/main/java/community/ddv/domain/board/service/forbiddenWordsFilter.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/forbiddenWordsFilter.java
@@ -1,0 +1,37 @@
+package community.ddv.domain.board.service;
+
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class forbiddenWordsFilter {
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  public forbiddenWordsFilter(@Qualifier("redisForbiddenWordsTemplate") RedisTemplate<String, String> redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  public Set<String> getForbiddenWords() {
+    return redisTemplate.opsForSet().members("forbidden-words");
+  }
+
+  public String filterForbiddenWords(String input) {
+    if (input == null || input.isEmpty()) {
+      return input;
+    }
+    Set<String> forbiddenWords = getForbiddenWords();
+    for (String word : forbiddenWords) {
+      if (input.contains(word)) {
+        String masked = "*".repeat(word.length());
+        input = input.replace(word, masked);
+      }
+    }
+    return input;
+  }
+}
+

--- a/ddv/src/main/java/community/ddv/domain/user/controller/EmailController.java
+++ b/ddv/src/main/java/community/ddv/domain/user/controller/EmailController.java
@@ -1,0 +1,42 @@
+package community.ddv.domain.user.controller;
+
+import community.ddv.domain.user.dto.EmailDto.EmailRequest;
+import community.ddv.domain.user.dto.EmailDto.EmailVerifyRequest;
+import community.ddv.domain.user.dto.EmailDto.EmailVerifyResponse;
+import community.ddv.domain.user.service.EmailService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/emails")
+@RequiredArgsConstructor
+@Tag(name = "Email", description = "이메일 인증 API에 대한 명세를 제공합니다.")
+public class EmailController {
+
+  private final EmailService emailService;
+
+  @PostMapping("/send")
+  public ResponseEntity<Void> sendCode(
+      @RequestBody EmailRequest emailRequest
+  ) {
+    emailService.sendAuthCode(emailRequest.getEmail());
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/verify")
+  public ResponseEntity<EmailVerifyResponse> verifyCode(
+      @RequestBody EmailVerifyRequest verifyRequest
+  ) {
+    boolean isValid = emailService.verifyAuthCode(verifyRequest.getEmail(), verifyRequest.getCode());
+    if (isValid) {
+      return ResponseEntity.ok(new EmailVerifyResponse(true));
+    } else {
+      return ResponseEntity.badRequest().body(new EmailVerifyResponse(false));
+    }
+  }
+}

--- a/ddv/src/main/java/community/ddv/domain/user/dto/EmailDto.java
+++ b/ddv/src/main/java/community/ddv/domain/user/dto/EmailDto.java
@@ -1,0 +1,25 @@
+package community.ddv.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public class EmailDto {
+
+  @Getter
+  public static class EmailRequest {
+    private String email;
+  }
+
+  @Getter
+  public static class EmailVerifyRequest {
+    private String email;
+    private String code;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class EmailVerifyResponse {
+    private boolean success;
+  }
+}

--- a/ddv/src/main/java/community/ddv/domain/user/service/EmailService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/EmailService.java
@@ -1,0 +1,52 @@
+package community.ddv.domain.user.service;
+
+import java.time.Duration;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+  private final JavaMailSender mailSender;
+  private final RedisTemplate<String, String> redisStringTemplate;
+
+  // 인증코드 생성 & 이메일 전송
+  public void sendAuthCode(String email) {
+    String authCode = createRandomCode();
+
+    redisStringTemplate.opsForValue().set("authCode:" + email, authCode, Duration.ofMinutes(5));
+    SimpleMailMessage message = new SimpleMailMessage();
+    message.setTo(email);
+    message.setSubject("[DeepDiview] 이메일 인증 코드");
+    message.setText("인증 코드 : " + authCode + "\n5분 내로 입력해주세요");
+    mailSender.send(message);
+
+  }
+
+  // 인증코드 검증
+  public boolean verifyAuthCode(String email, String authCode) {
+    String key = "authCode:" + email;
+    String savedCode = redisStringTemplate.opsForValue().get(key);
+    if (authCode.equals(savedCode)) {
+      redisStringTemplate.delete(key);
+      redisStringTemplate.opsForValue().set("EMAIL_VERIFIED:" + email, "true", Duration.ofMinutes(10));
+      return true;
+    }
+    return false;
+  }
+
+  public boolean isVerified(String email) {
+    return "true".equals(redisStringTemplate.opsForValue().get("EMAIL_VERIFIED:" + email));
+  }
+
+  private String createRandomCode() {
+    Random random = new Random();
+    int code = 100000 + random.nextInt(900000); // 6자리 난수
+    return String.valueOf(code);
+  }
+}

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -386,7 +386,7 @@ public class UserService {
 
     CertificationStatus certificationStatus =
         certification != null
-            ? certification.getStatus() : null;
+            ? certification.getStatus() : CertificationStatus.NONE;
 
     RejectionReason rejectionReason =
         certification != null && certification.getStatus() == CertificationStatus.REJECTED

--- a/ddv/src/main/java/community/ddv/global/component/JwtFilter.java
+++ b/ddv/src/main/java/community/ddv/global/component/JwtFilter.java
@@ -28,7 +28,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
   private final JwtProvider jwtProvider;
   private final UserDetailsService userDetailsService;
-  private final RedisTemplate<String, String> redisTokenTemplate;
+  private final RedisTemplate<String, String> redisStringTemplate;
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -38,7 +38,7 @@ public class JwtFilter extends OncePerRequestFilter {
     String token = jwtProvider.extractToken(request);
     try {
       if (token != null) {
-        String isBlacked = redisTokenTemplate.opsForValue().get(token);
+        String isBlacked = redisStringTemplate.opsForValue().get(token);
         if ("logout".equals(isBlacked)) {
           log.warn("블랙리스트로 등록된 토큰. 접근 거부");
           setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "로그아웃된 토큰입니다.");

--- a/ddv/src/main/java/community/ddv/global/config/RedisConfig.java
+++ b/ddv/src/main/java/community/ddv/global/config/RedisConfig.java
@@ -43,6 +43,15 @@ public class RedisConfig {
   }
 
   @Bean
+  RedisTemplate<String, String> redisForbiddenWordsTemplate() {
+    RedisTemplate<String, String> template = new RedisTemplate<>();
+    template.setConnectionFactory(redisConnectionFactory());
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new StringRedisSerializer());
+    return template;
+  }
+
+  @Bean
   public RedisTemplate<String, Long> redisVoteResultTemplate() {
     RedisTemplate<String, Long> template = new RedisTemplate<>();
     template.setConnectionFactory(redisConnectionFactory());

--- a/ddv/src/main/java/community/ddv/global/config/RedisConfig.java
+++ b/ddv/src/main/java/community/ddv/global/config/RedisConfig.java
@@ -32,18 +32,8 @@ public class RedisConfig {
     return new LettuceConnectionFactory(redisHost, redisPort);
   }
 
-  // 리프레시 토큰 용 RedisTemplate
   @Bean
-  RedisTemplate<String, String> redisTokenTemplate() {
-    RedisTemplate<String, String> template = new RedisTemplate<>();
-    template.setConnectionFactory(redisConnectionFactory());
-    template.setKeySerializer(new StringRedisSerializer());
-    template.setValueSerializer(new StringRedisSerializer());
-    return template;
-  }
-
-  @Bean
-  RedisTemplate<String, String> redisForbiddenWordsTemplate() {
+  RedisTemplate<String, String> redisStringTemplate() {
     RedisTemplate<String, String> template = new RedisTemplate<>();
     template.setConnectionFactory(redisConnectionFactory());
     template.setKeySerializer(new StringRedisSerializer());

--- a/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
+++ b/ddv/src/main/java/community/ddv/global/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
       "/swagger-ui/**",
       "/api/users/signup",
       "/api/users/login",
+      "/api/emails/**",
       "/api/fetch/genres",
       "/api/fetch/movies",
       "/api/fetch/runtimes",

--- a/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
   // 사용자 관련 에러코드
+  EMAIL_NOT_VERIFIED("이메일 인증을 해주세요", HttpStatus.BAD_REQUEST),
   ALREADY_EXIST_MEMBER("이미 존재하는 사용자입니다.", HttpStatus.BAD_REQUEST),
   ALREADY_EXIST_NICKNAME("이미 존재하는 닉네임입니다. 다른 닉네임을 작성해주세요", HttpStatus.BAD_REQUEST),
   NOT_VALID_PASSWORD("비밀번호가 일치하지 않습니다. 비밀번호를 다시 확인해주세요", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
# [변경사항]

1. 리뷰/댓글 작성/수정 시 제목이나 내용에 욕설이 포함된 경우, *로 필터링되어 나오도록 기능을 추가했습니다. 
    - 허용되지 않은 단어 길이만큼 *이 나오도록 구현했습니다. 
2. 회원가입 시 이메일로 인증코드를 보내는 기능을 구현했습니다. 
    - 요청방식 : 
      > POST /api/emails/send
{
  "email": "메일주소"
}
3. 이메일을 통해 받은 코드를 인증하는 기능을 구현했습니다.   
    - 요청방식 : 
      > POST /api/emails/verify
      {
  "email": "메일주소",
  "code": "인증코드 
  }
  
     - 반환 : 
       > {
  "success": true/false
}

4. 인증코드를 작성하지 않고 회원가입 시도시, 예외 메시지가 반환됩니다. 
5. 인증시도를 하지 않았던 사용자가 자신의 정보 조회시, 인증상태가 null로 나오던 것을 NONE으로 나오도록 수정했습니다. 