### PR TITLE
feat : 이메일 인증 번호 전송시 HTML 형식으로 전송하도록 추가, 이메일 인증 실패시 예외처리 추가 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/user/controller/EmailController.java
+++ b/ddv/src/main/java/community/ddv/domain/user/controller/EmailController.java
@@ -2,7 +2,6 @@ package community.ddv.domain.user.controller;
 
 import community.ddv.domain.user.dto.EmailDto.EmailRequest;
 import community.ddv.domain.user.dto.EmailDto.EmailVerifyRequest;
-import community.ddv.domain.user.dto.EmailDto.EmailVerifyResponse;
 import community.ddv.domain.user.service.EmailService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -29,14 +28,10 @@ public class EmailController {
   }
 
   @PostMapping("/verify")
-  public ResponseEntity<EmailVerifyResponse> verifyCode(
+  public ResponseEntity<Void> verifyCode(
       @RequestBody EmailVerifyRequest verifyRequest
   ) {
-    boolean isValid = emailService.verifyAuthCode(verifyRequest.getEmail(), verifyRequest.getCode());
-    if (isValid) {
-      return ResponseEntity.ok(new EmailVerifyResponse(true));
-    } else {
-      return ResponseEntity.badRequest().body(new EmailVerifyResponse(false));
-    }
+    emailService.verifyAuthCode(verifyRequest.getEmail(), verifyRequest.getCode());
+    return ResponseEntity.ok().build();
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/user/dto/EmailDto.java
+++ b/ddv/src/main/java/community/ddv/domain/user/dto/EmailDto.java
@@ -2,7 +2,6 @@ package community.ddv.domain.user.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 public class EmailDto {
 

--- a/ddv/src/main/java/community/ddv/domain/user/dto/EmailDto.java
+++ b/ddv/src/main/java/community/ddv/domain/user/dto/EmailDto.java
@@ -16,9 +16,4 @@ public class EmailDto {
     private String code;
   }
 
-  @Getter
-  @AllArgsConstructor
-  public static class EmailVerifyResponse {
-    private boolean success;
-  }
 }

--- a/ddv/src/main/java/community/ddv/domain/user/service/EmailService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/EmailService.java
@@ -1,11 +1,13 @@
 package community.ddv.domain.user.service;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import java.time.Duration;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,12 +22,35 @@ public class EmailService {
     String authCode = createRandomCode();
 
     redisStringTemplate.opsForValue().set("authCode:" + email, authCode, Duration.ofMinutes(5));
-    SimpleMailMessage message = new SimpleMailMessage();
-    message.setTo(email);
-    message.setSubject("[DeepDiview] 이메일 인증 코드");
-    message.setText("인증 코드 : " + authCode + "\n5분 내로 입력해주세요");
-    mailSender.send(message);
 
+//    SimpleMailMessage message = new SimpleMailMessage();
+//    message.setTo(email);
+//    message.setSubject("[DeepDiview] 이메일 인증 코드");
+//    message.setText("인증 코드 : " + authCode + "\n5분 내로 입력해주세요");
+
+    try {
+      MimeMessage message = mailSender.createMimeMessage();
+      MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+      helper.setTo(email);
+      helper.setSubject("[DeepDiview] 이메일 인증 코드");
+      helper.setText(buildEmailHTML(authCode), true);
+      mailSender.send(message);
+    } catch (MessagingException e) {
+      throw new RuntimeException("인증 코드 전송 실패", e);
+    }
+  }
+
+  private String buildEmailHTML(String authCode) {
+    return """
+        <div style="width: 100%%; text-align: center; font-family: Arial, sans-serif; padding: 20px;">
+          <h2 style="color: #4b4bfc;">[DeepDiview] 이메일 인증 코드</h2>
+          <p>아래의 인증 코드를 5분 내에 입력해주세요.</p>
+          <div style="display: inline-block; padding: 15px 30px; background-color: #e0e0ff;
+                      border: 2px solid #5f5dff; border-radius: 10px; margin-top: 20px;">
+            <span style="font-size: 25px; font-weight: bold; color: #4b4bfc;">%s</span>
+          </div>
+        </div>
+        """.formatted(authCode);
   }
 
   // 인증코드 검증
@@ -40,10 +65,12 @@ public class EmailService {
     return false;
   }
 
+  // 인증 여부 확인 메서드
   public boolean isVerified(String email) {
     return "true".equals(redisStringTemplate.opsForValue().get("EMAIL_VERIFIED:" + email));
   }
 
+  // 인증코드 6자리 난수 생성 메서드
   private String createRandomCode() {
     Random random = new Random();
     int code = 100000 + random.nextInt(900000); // 6자리 난수

--- a/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
   // 사용자 관련 에러코드
+  EXPIRED_CODE("만료된 코드입니다.", HttpStatus.BAD_REQUEST),
+  INVALID_CODE("코드가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
   EMAIL_NOT_VERIFIED("이메일 인증을 해주세요", HttpStatus.BAD_REQUEST),
   ALREADY_EXIST_MEMBER("이미 존재하는 사용자입니다.", HttpStatus.BAD_REQUEST),
   ALREADY_EXIST_NICKNAME("이미 존재하는 닉네임입니다. 다른 닉네임을 작성해주세요", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
# [변경사항]

1. 이메일 본문을 Text로만 보내는 것 대신 HTML 형식으로 작성하기 위해 SimpleMailMessage -> MimeMessag,  MimeMessageHelper 적용
2. 이메일 인증 코드 검증 메서드의 반환 타입 변경 (boolean → void)
3. 인증 실패 시 예외 발생 추가
    - 인증 코드 만료시: `EXPIRED_CODE`
    - > {
  "errorCode": "EXPIRED_CODE",
  "errorMessage": "만료된 코드입니다.",
  "validErrors": null
}


    - 인증 코드 불일치: `INVALID_CODE`
    - > {
  "errorCode": "INVALID_CODE",
  "errorMessage": "코드가 일치하지 않습니다.",
  "validErrors": null
}


    - 성공시 : 200 OK 
