### PR TITLE
feat : 인증 정보 조회시 DTO 반환형태 변경, 일요일에는 인증 정보를 조회할 수 없도록 예외 처리 추가 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationController.java
@@ -1,8 +1,8 @@
 package community.ddv.domain.certification;
 
 import community.ddv.domain.certification.CertificationDTO.CertificationRequestDto;
-import community.ddv.domain.certification.CertificationDTO.CertificationResponseDto;
 import community.ddv.domain.certification.constant.CertificationStatus;
+import community.ddv.domain.certification.CertificationDTO.CertificationWrapperDto;
 import community.ddv.global.response.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,7 +33,7 @@ public class CertificationController {
 
   @Operation(summary = "인증샷 제출", description = "파일 업로드")
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<CertificationResponseDto> submitCertification(
+  public ResponseEntity<CertificationWrapperDto> submitCertification(
       @Parameter(description = "인증샷 파일")
       @RequestParam("file") MultipartFile file) {
     return ResponseEntity.ok(certificationService.submitCertification(file));
@@ -41,14 +41,13 @@ public class CertificationController {
 
   @Operation(summary = "인증샷, 상태 확인", description = "인증샷 url, 인증상태 반환")
   @GetMapping("/me")
-  public ResponseEntity<CertificationResponseDto> getCertification() {
-    CertificationResponseDto certificationResponseDto = certificationService.getMyCertification();
-    return ResponseEntity.ok(certificationResponseDto);
+  public ResponseEntity<CertificationWrapperDto> getCertification() {
+    return ResponseEntity.ok(certificationService.getMyCertification());
   }
 
   @Operation(summary = "인증샷 수정", description = "파일 재업로드, PENDING/REJECTED 상태의 유저만 사용 가능")
   @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<CertificationResponseDto> updateCertification(
+  public ResponseEntity<CertificationWrapperDto> updateCertification(
       @Parameter(description = "인증샷 파일")
       @RequestParam("file") MultipartFile file) {
     return ResponseEntity.ok(certificationService.updateCertification(file));
@@ -63,14 +62,14 @@ public class CertificationController {
 
   @Operation(summary = "인증 목록 조회 (실시간성 보장을 위해 커서기반 페이징 사용)", description = "관리자 전용 - 보류, 승인, 거절 필터링 가능 | 한 번에 10개씩 반환 ㅣ 인증요청을 한 지 오래된 순서대로 정렬됩니다.")
   @GetMapping("/admin")
-  public ResponseEntity<CursorPageResponse<CertificationResponseDto>> getPendingCertifications(
+  public ResponseEntity<CursorPageResponse<CertificationWrapperDto>> getPendingCertifications(
       @Parameter(description = "PENDING, APPROVED, REJECTED만 사용")
       @RequestParam(required = false) CertificationStatus status,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdAt,
       @RequestParam(required = false) Long certificationId,
       @RequestParam(defaultValue = "10") int size)
   {
-    CursorPageResponse<CertificationResponseDto> certifications =
+    CursorPageResponse<CertificationWrapperDto> certifications =
         certificationService.getCertificationsByStatus(status, createdAt, certificationId, size);
     return ResponseEntity.ok(certifications);
   }
@@ -78,10 +77,11 @@ public class CertificationController {
 
   @Operation(summary = "인증 승인/거절", description = "관리자 전용 - 승인 : true / 거절 : false | 거절시 rejectionReason: OTHER_MOVIE_IMAGE, WRONG_IMAGE, UNIDENTIFIABLE_IMAGE")
   @PostMapping("/admin/proceeding/{certificationId}")
-  public ResponseEntity<CertificationResponseDto> proceedCertification(
+  public ResponseEntity<CertificationWrapperDto> proceedCertification(
       @PathVariable Long certificationId,
       @RequestBody CertificationRequestDto requestDto) {
-    CertificationResponseDto responseDto = certificationService.proceedCertification(certificationId, requestDto.isApprove(), requestDto.getRejectionReason());
+    CertificationWrapperDto responseDto =
+        certificationService.proceedCertification(certificationId, requestDto.isApprove(), requestDto.getRejectionReason());
     return ResponseEntity.ok(responseDto);
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationDTO.java
@@ -19,12 +19,19 @@ public class CertificationDTO {
 
     @Getter
     @Builder
-    public static class CertificationResponseDto {
+    public static class CertificationWrapperDto {
+
+        private CertificationStatus status;
+        private CertificationDetailResponseDto certificationDetails;
+    }
+
+    @Getter
+    @Builder
+    public static class CertificationDetailResponseDto {
 
         private Long id;
         private Long userId;
         private String certificationUrl;
-        private CertificationStatus status;
         private LocalDateTime createdAt;
         private RejectionReason rejectionReason;
     }

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -81,6 +81,8 @@ public class CertificationService {
    */
   @Transactional(readOnly = true)
   public CertificationWrapperDto getMyCertification() {
+
+    validateSunday(); // 일요일에는 확인 불가
     User user = userService.getLoginUser();  // 로그인된 사용자 정보 가져오기
 
     LocalDate startOfWeek = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
@@ -169,6 +171,8 @@ public class CertificationService {
   @Transactional(readOnly = true)
   public CursorPageResponse<CertificationWrapperDto> getCertificationsByStatus(
       CertificationStatus status, LocalDateTime cursorCreatedAt, Long cursorId, int size) {
+
+    validateSunday(); // 일요일에는 확인 불가
 
     log.info("관리자의 인증 목록 조회 시작");
     User admin = userService.getLoginUser();
@@ -263,6 +267,12 @@ public class CertificationService {
     return certificationRepository.existsByUser_IdAndStatus(userId, CertificationStatus.APPROVED);
   }
 
+  private void validateSunday() {
+    if (LocalDate.now().getDayOfWeek() == DayOfWeek.SUNDAY) {
+      throw new DeepdiviewException(ErrorCode. CERTIFICATION_CHECK_NOT_ALLOWED_ON_SUNDAY);
+    }
+  }
+
 
   private CertificationWrapperDto certificationResponse(Certification certification) {
 
@@ -299,7 +309,7 @@ public class CertificationService {
     LocalDateTime startOfWeek = LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay();
     LocalDateTime endOfWeek = LocalDate.now().with(DayOfWeek.SATURDAY).atTime(LocalTime.MAX);
     // 테스트용 endOfWeek
-    //ocalDateTime endOfWeek = LocalDateTime.now();
+    //localDateTime endOfWeek = LocalDateTime.now();
 
     List<Certification> certifications = certificationRepository.findAllByCreatedAtBetween(startOfWeek, endOfWeek);
     if (certifications.isEmpty()) {

--- a/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/UserService.java
@@ -398,7 +398,7 @@ public class UserService {
         ).orElse(null);
 
     CertificationStatus certificationStatus =
-        certification != null
+        certification != null && certification.getStatus() != null
             ? certification.getStatus() : CertificationStatus.NONE;
 
     RejectionReason rejectionReason =

--- a/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
 
   // 인증 관련 에러코드
   CERTIFICATION_NOT_ALLOWED_ON_SUNDAY("인증 가능 기간은 '월-토'입니다.", HttpStatus.BAD_REQUEST),
+  CERTIFICATION_CHECK_NOT_ALLOWED_ON_SUNDAY("일요일에는 인증 상태를 확인할 수 없습니다.", HttpStatus.BAD_REQUEST),
   CERTIFICATION_NOT_FOUND("인증요청이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
   ALREADY_APPROVED("이미 승인되었습니다.", HttpStatus.BAD_REQUEST),
 


### PR DESCRIPTION
# [변경사항]

1. CertificationDTO에서 status 필드를 독립시키고, 나머지 정보들은 한번에 묶어 반환하도록 수정했습니다. 
  - status가 NONE인 경우, 나머지 정보들은 모두 null이기 때문에 하나의 null로 반환하는 것이 낫겠다는 판단이 들어 래퍼DTO를 만들었습니다.
    - 수정 전 : 
    ```
    {
     "id": ,
     "userId": ,
     "certificationUrl": "",
     "status": "REJECTED",
     "createdAt": "",
     "rejectionReason": "UNIDENTIFIABLE_IMAGE"
     }
     ```
  
    - 수정 후 

    ```
    {
    "status": "REJECTED",
    "certificationDetails": {
      "id": ,
      "userId": ,
      "certificationUrl": "",
      "createdAt": "",
      "rejectionReason": "UNIDENTIFIABLE_IMAGE"
    }
    },
    {
    "status": "NONE",
    "certificationDetails": null
    }
    ```
 
2. 인증상태 정보를 DTO로 반환하는 코드가 반복되어 따로 메서드로 만들어 분리했습니다. 

3. 일요일에는 사용자/관리자 모두 인증상태를 확인할 수 없도록 예외처리하였습니다. 