### PR TITLE
feat : 알림 응답값 변경 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/notification/Notification.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/Notification.java
@@ -32,6 +32,8 @@ public class Notification {
   @Enumerated(EnumType.STRING)
   private NotificationType notificationType; // 알림 타입/메시지
 
+  private Long relatedId; // 알림대상(리뷰, 인증 id)
+
   private boolean isRead; // 확인 여부
 
   public void markAsRead() {

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
@@ -5,6 +5,8 @@ import community.ddv.domain.user.service.UserService;
 import community.ddv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
@@ -45,10 +47,11 @@ public class NotificationController {
 
   @Operation(summary = "특정 알림 읽음처리")
   @PutMapping("/{notificationId}/read")
-  public ResponseEntity<Void> markNotificationAsRead(
+  public ResponseEntity<Map<String, Boolean>> markNotificationAsRead(
       @PathVariable Long notificationId) {
-    notificationService.markNotificationAsRead(notificationId);
-    return ResponseEntity.noContent().build();
+    boolean hasUnread = notificationService.markNotificationAsRead(notificationId);
+    Map<String, Boolean> response = Map.of("hasUnread", hasUnread);
+    return ResponseEntity.ok(response);
   }
 
   @Operation(summary = "전체 알림 읽음처리")
@@ -60,9 +63,10 @@ public class NotificationController {
 
   @Operation(summary = "안 읽은 알림 여부 확인용")
   @GetMapping("/unread-exists")
-  public ResponseEntity<Boolean> hasUnreadNotifications() {
-    boolean result = notificationService.isNotReadNotification();
-    return ResponseEntity.ok(result);
+  public ResponseEntity<Map<String, Boolean>> hasUnreadNotifications() {
+    boolean hasUnread = notificationService.isNotReadNotification();
+    Map<String, Boolean> response = Map.of("hasUnread", hasUnread);
+    return ResponseEntity.ok(response);
   }
 
 }

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -293,7 +293,7 @@ public class NotificationService {
    * 특정 알림 읽음 처리
    * @param notificationId
    */
-  public void markNotificationAsRead(Long notificationId) {
+  public boolean markNotificationAsRead(Long notificationId) {
     User user = userService.getLoginUser();
     log.info("알림 읽음 시도 : userId = {}", user.getId());
     Notification notification = notificationRepository.findByIdAndUser_Id(notificationId,user.getId())
@@ -304,6 +304,8 @@ public class NotificationService {
       notificationRepository.save(notification);
       log.info("알림 읽음처리 완료");
     }
+
+    return notificationRepository.existsByUser_IdAndIsReadFalse(user.getId());
   }
 
   /**

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationType.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationType.java
@@ -7,7 +7,8 @@ public enum NotificationType {
 
   COMMENT_ADDED("내 리뷰에 새 댓글이 달렸습니다."),
   LIKE_ADDED("내 리뷰에 좋아요가 달렸습니다."),
-  CERTIFICATION_RESULT("인증 결과를 확인하세요.");
+  CERTIFICATION_APPROVED("인증이 승인되었습니다."),
+  CERTIFICATION_REJECTED("인증이 거절되었습니다.");
 
   private final String message;
 

--- a/ddv/src/main/java/community/ddv/domain/notification/dto/NotificationDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/dto/NotificationDTO.java
@@ -1,5 +1,6 @@
 package community.ddv.domain.notification.dto;
 
+import community.ddv.domain.notification.NotificationType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,8 +9,9 @@ import lombok.Getter;
 public class NotificationDTO {
 
   private Long notificationId;
-  private String type;
-  private String message;
-  private Long relatedId; // 댓글이 달린 리뷰 ID , 인증 ID
+  private NotificationType notificationType;
+//  private String type;
+//  private String message;
+//  private Long relatedId; // 댓글이 달린 리뷰 ID , 인증 ID
 
 }

--- a/ddv/src/main/java/community/ddv/domain/notification/dto/NotificationResponseDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/dto/NotificationResponseDTO.java
@@ -1,5 +1,6 @@
 package community.ddv.domain.notification.dto;
 
+import community.ddv.domain.notification.NotificationType;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,7 +13,9 @@ import lombok.NoArgsConstructor;
 @Builder
 public class NotificationResponseDTO {
   private Long notificationId;
+  private NotificationType notificationType;
   private String message;
+  private Long relatedId;
   private boolean isRead;
   private LocalDateTime createdAt;
 


### PR DESCRIPTION
# [변경사항]

1. 알림 읽음처리 응답으로 안 읽은 알림 유무를 boolean으로 포함하여 보내도록 추가했습니다. 
   ```
   {
    "hasUnread": boolean
    }
    ```
2. 안 읽은 알림 존재 여부 응답시, boolean -> 키-값 형태로 응답으로 수정했습니다. 
   ```
   {
    "hasUnread": boolean
    }
    ```
3. 알림 응답 수정 
    - notificationType : COMMENT_ADDED, LIKE_ADDED, CERTIFICATION_APPROVED, CERTIFICATION_REJECTED
    ```
    {
        "notificationId": ,
        "notificationType": ""
     }
    ```
4. 알림목록 조회 응답 수정 
  - Notification 엔티티에 relatedId 컬럼이 새로 추가되었습니다. 
    - 이전의 알림에는 relatedId가 없었기 때문에 null로 반환됩니다. 
    - relatedId는 해당하는 리뷰id, 인증id로 들어갑니다. 
    ```` 
     {
      "notificationId": ,
      "notificationType": "",
      "message": ".",
      "relatedId": ,
      "createdAt": "",
      "read": boolean
    }
    ````
