### PR TITLE
fix : 커서기반임에도 불구하고 createdAt 이전의 데이터가 나오는 이슈 해결 1

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationRepository.java
@@ -17,26 +17,34 @@ public interface CertificationRepository extends JpaRepository<Certification, Lo
   boolean existsByUser_IdAndStatus(Long userId, CertificationStatus status);
 
   // 상태별 조회
-  @Query("SELECT c FROM Certification c WHERE " +
-      "( c.status = :status) AND " +
-      "((c.createdAt > :createdAt) OR (c.createdAt = :createdAt AND c.id > :id)) " +
-      "ORDER BY c.createdAt ASC, c.id ASC")
+  @Query("""
+        SELECT c FROM Certification c
+        WHERE(c.status = :status)
+        AND ((c.createdAt > :createdAt) OR (c.createdAt = :createdAt AND c.id > :id))
+        AND c.createdAt <= :endOfWeek
+        ORDER BY c.createdAt ASC, c.id ASC
+        """)
   List<Certification> findByStatusWithCursor(
       @Param("status") CertificationStatus status,
       @Param("createdAt") LocalDateTime createdAt,
       @Param("id") Long id,
+      @Param("endOfWeek") LocalDateTime endOfWeek,
       Pageable pageable
   );
 
   // 전체 조회
-  @Query("SELECT c FROM Certification c WHERE " +
-      "(c.status IS NOT NULL) AND " +
-      "((c.createdAt > :createdAt) OR (c.createdAt = :createdAt AND c.id > :id)) " +
-      "ORDER BY c.createdAt ASC, c.id ASC")
+  @Query("""
+      SELECT c FROM Certification c
+      WHERE (c.status IS NOT NULL)
+      AND ((c.createdAt > :createdAt) OR (c.createdAt = :createdAt AND c.id > :id))
+      AND c.createdAt <= :endOfWeek
+      ORDER BY c.createdAt ASC, c.id ASC
+      """)
   List<Certification> findAllWithCursor(
     @Param("createdAt") LocalDateTime createdAt,
     @Param("id") Long id,
-    Pageable pageable
+    @Param("endOfWeek") LocalDateTime endOfWeek,
+      Pageable pageable
   );
 
 

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -181,9 +181,15 @@ public class CertificationService {
       throw new DeepdiviewException(ErrorCode.ONLY_ADMIN_CAN);
     }
 
+    LocalDateTime startOfWeek = getStartOfThisWeek();
+    LocalDateTime endOfWeek = getEndOfThisWeek();
+
     // 처음 목록 요청시, 커서정보가 없기 때문에 가장 오래된 시간, 0L로 기본값으로 주기
-    if (cursorCreatedAt == null) {
-      cursorCreatedAt = LocalDateTime.MIN;
+//    if (cursorCreatedAt == null) {
+//      cursorCreatedAt = LocalDateTime.MIN;
+//    }
+    if (cursorCreatedAt == null || cursorCreatedAt.isBefore(startOfWeek)) {
+      cursorCreatedAt = startOfWeek;
     }
     if (cursorId == null) {
       cursorId = 0L;
@@ -196,11 +202,11 @@ public class CertificationService {
     if (status == null) {
       // 전체 조회
       log.info("인증 전체 조회");
-      certifications = certificationRepository.findAllWithCursor(cursorCreatedAt, cursorId, pageable);
+      certifications = certificationRepository.findAllWithCursor(cursorCreatedAt, cursorId, endOfWeek, pageable);
     } else {
       // 인증 상태에 따른 조회
       log.info("인증 상태에 따른 조회 : status = {}", status);
-      certifications = certificationRepository.findByStatusWithCursor(status,cursorCreatedAt, cursorId, pageable);
+      certifications = certificationRepository.findByStatusWithCursor(status,cursorCreatedAt, cursorId, endOfWeek, pageable);
     }
 
     // 다음 페이지 존재 여부 판단
@@ -328,4 +334,15 @@ public class CertificationService {
     certificationRepository.resetAllCertifications();
   }
 
+  private LocalDateTime getStartOfThisWeek() {
+    return LocalDate.now()
+        .with(DayOfWeek.MONDAY)
+        .atStartOfDay();
+  }
+
+  private LocalDateTime getEndOfThisWeek() {
+    return LocalDate.now()
+        .with(DayOfWeek.SATURDAY)
+        .atTime(LocalTime.MAX);
+  }
 }


### PR DESCRIPTION
# [변경사항]

1. 커서기반 첫 조회시, createdAt 이전의 데이터까지 반환되는 이슈 발생
2. 타임존 문제일 것이라 생각했으나, 일단은 이번주 내에 제출된 인증들만 가져와서 반환하는 것으로 수정해보기로 함
3. 첫 요청시 아무런 쿼리 파라미터를 넣지 않으면 이 주의 첫 인증부터 조회되도록 수정 
