### PR TITLE
feat : 30일치 인증 내역만 볼 수 있도록 수정, enum 이름 변경

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationRepository.java
@@ -1,5 +1,6 @@
 package community.ddv.domain.notification;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -11,8 +12,9 @@ import org.springframework.stereotype.Repository;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
   Optional<Notification> findByIdAndUser_Id(Long notificationId, Long userId);
-  Page<Notification> findByUser_IdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+  Page<Notification> findByUser_IdAndCreatedAtAfterOrderByCreatedAtDesc(Long userId, LocalDateTime dayBeforeOneMonth, Pageable pageable);
   List<Notification> findByUser_IdAndIsReadFalseOrderByCreatedAtDesc(Long userId);
   boolean existsByUser_IdAndIsReadFalse(Long userId);
+  void deleteByCreatedAtBefore(LocalDateTime cutoff);
 
 }

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationType.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationType.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public enum NotificationType {
 
   NEW_COMMENT("내 리뷰에 새 댓글이 달렸습니다."),
-  NEW_LIKE_ADDED("내 리뷰에 좋아요가 달렸습니다."),
+  NEW_LIKE("내 리뷰에 좋아요가 달렸습니다."),
   CERTIFICATION_APPROVED("인증이 승인되었습니다."),
   CERTIFICATION_REJECTED("인증이 거절되었습니다.");
 

--- a/ddv/src/main/java/community/ddv/global/component/Scheduler.java
+++ b/ddv/src/main/java/community/ddv/global/component/Scheduler.java
@@ -61,5 +61,13 @@ public class Scheduler {
     log.info("인증상태 초기화 완료");
   }
 
+  // 매일 새벽 3시, 31일된 알림 삭제 처리 스케줄링
+//  @Scheduled(cron = "0 0 3 * * *")
+//  public void deleteOldNotifications() {
+//    log.info("31일 이상 지난 알림 삭제 시작");
+//    certificationService.deleteCertification();
+//    log.info("31일 이상 지난 알림 삭제 완료");
+//  }
+
 }
 


### PR DESCRIPTION
# [변경사항]

1. 현재로부터 30일 전의 알림들만 볼 수 있도록 제한했습니다. 
2. enum이름이 잘못 들어가서 수정했습니다. 