### PR TITLE
feat : 31이상 지난 알림 삭제 스케줄링 추가 & 인증 처리시 예외처리 추가 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationController.java
@@ -7,6 +7,7 @@ import community.ddv.global.response.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -79,9 +80,9 @@ public class CertificationController {
   @PostMapping("/admin/proceeding/{certificationId}")
   public ResponseEntity<CertificationWrapperDto> proceedCertification(
       @PathVariable Long certificationId,
-      @RequestBody CertificationRequestDto requestDto) {
+      @RequestBody @Valid CertificationRequestDto requestDto) {
     CertificationWrapperDto responseDto =
-        certificationService.proceedCertification(certificationId, requestDto.isApprove(), requestDto.getRejectionReason());
+        certificationService.proceedCertification(certificationId, requestDto.getApprove(), requestDto.getRejectionReason());
     return ResponseEntity.ok(responseDto);
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationDTO.java
@@ -2,6 +2,7 @@ package community.ddv.domain.certification;
 
 import community.ddv.domain.certification.constant.CertificationStatus;
 import community.ddv.domain.certification.constant.RejectionReason;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,8 @@ public class CertificationDTO {
     @Getter
     public static class CertificationRequestDto {
 
-        private boolean approve;
+        @NotNull(message = "승인 여부를 선택해주세요")
+        private Boolean approve;
         private RejectionReason rejectionReason;
     }
 

--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -247,6 +247,14 @@ public class CertificationService {
       log.error("관리자만 처리 가능합니다.");
       throw new DeepdiviewException(ErrorCode.ONLY_ADMIN_CAN);
     }
+
+    if (!approve && rejectionReason == null) {
+      throw new DeepdiviewException(ErrorCode.REJECTION_REASON_REQUIRED);
+    }
+    if (approve && rejectionReason != null) {
+      throw new DeepdiviewException(ErrorCode.APPROVAL_SHOULD_NOT_HAVE_REASON);
+    }
+
     Certification certification = certificationRepository.findById(certificationId)
         .orElseThrow(() -> {
           log.error("인증 정보를 찾을 수 없음");

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationRepository.java
@@ -15,6 +15,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
   Page<Notification> findByUser_IdAndCreatedAtAfterOrderByCreatedAtDesc(Long userId, LocalDateTime dayBeforeOneMonth, Pageable pageable);
   List<Notification> findByUser_IdAndIsReadFalseOrderByCreatedAtDesc(Long userId);
   boolean existsByUser_IdAndIsReadFalse(Long userId);
-  void deleteByCreatedAtBefore(LocalDateTime cutoff);
+  void deleteByCreatedAtBefore(LocalDateTime notificationResetDay);
 
 }

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -285,8 +285,8 @@ public class NotificationService {
    */
   @Transactional
   public void deleteOldNotifications() {
-    LocalDateTime cutoff = LocalDateTime.now().minusDays(31);
-    notificationRepository.deleteByCreatedAtBefore(cutoff);
+    LocalDateTime notificationResetDay = LocalDateTime.now().minusDays(31);
+    notificationRepository.deleteByCreatedAtBefore(notificationResetDay);
   }
 
 

--- a/ddv/src/main/java/community/ddv/global/component/Scheduler.java
+++ b/ddv/src/main/java/community/ddv/global/component/Scheduler.java
@@ -2,6 +2,7 @@ package community.ddv.global.component;
 
 import community.ddv.domain.certification.CertificationService;
 import community.ddv.domain.movie.service.MovieApiService;
+import community.ddv.domain.notification.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
@@ -17,6 +18,7 @@ public class Scheduler {
   private final MovieApiService movieApiService;
   private final CacheManager cacheManager;
   private final CertificationService certificationService;
+  private final NotificationService notificationService;
 
   // 매주 일요일 0시 0분 5초에 영화 데이터 업데이트하면서 인기 영화 목록 캐시 초기화
   @Scheduled(cron = "5 0 0 * * SUN")
@@ -62,12 +64,12 @@ public class Scheduler {
   }
 
   // 매일 새벽 3시, 31일된 알림 삭제 처리 스케줄링
-//  @Scheduled(cron = "0 0 3 * * *")
-//  public void deleteOldNotifications() {
-//    log.info("31일 이상 지난 알림 삭제 시작");
-//    certificationService.deleteCertification();
-//    log.info("31일 이상 지난 알림 삭제 완료");
-//  }
+  @Scheduled(cron = "0 0 3 * * *")
+  public void deleteOldNotifications() {
+    log.info("31일 이상 지난 알림 삭제 시작");
+    notificationService.deleteOldNotifications();
+    log.info("31일 이상 지난 알림 삭제 완료");
+  }
 
 }
 

--- a/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
+++ b/ddv/src/main/java/community/ddv/global/exception/ErrorCode.java
@@ -57,6 +57,8 @@ public enum ErrorCode {
   CERTIFICATION_NOT_ALLOWED_ON_SUNDAY("인증 가능 기간은 '월-토'입니다.", HttpStatus.BAD_REQUEST),
   CERTIFICATION_CHECK_NOT_ALLOWED_ON_SUNDAY("일요일에는 인증 상태를 확인할 수 없습니다.", HttpStatus.BAD_REQUEST),
   CERTIFICATION_NOT_FOUND("인증요청이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+  REJECTION_REASON_REQUIRED("거절일 경우, 거절 사유는 필수입니다.", HttpStatus.BAD_REQUEST),
+  APPROVAL_SHOULD_NOT_HAVE_REASON("승인일 경우, 거절 사유를 입력하면 안 됩니다.",HttpStatus.BAD_REQUEST),
   ALREADY_APPROVED("이미 승인되었습니다.", HttpStatus.BAD_REQUEST),
 
   // 토론 관련 에러코드


### PR DESCRIPTION
# [변경사항]

- 30일 전의 알림까지만 알림 내역을 보여주게 되면서
받은 지 31일 이상된 알림은 DB에서 삭제하도록 추가했습니다. 
  - 매일 새벽 3시마다 스케줄링이 실행됩니다. 
- 인증 처리시 approve를 적지 않았을 시 유효성 검사를 추가했습니다. 

> {
  "errorCode": "VALIDATION_FAILED",
  "errorMessage": "입력한 값에 오류가 있습니다.",
  "validErrors": {
    "approve": "승인 여부를 선택해주세요"
  }
}

- 인증 처리시 인승 상태에 따라 예외 처리를 추가했습니다. 
- 승인임에도 거절 사유를 입력하면 예외 처리 했습니다. 
>   - {
>   "errorCode": "APPROVAL_SHOULD_NOT_HAVE_REASON",
>   "errorMessage": "승인일 경우, 거절 사유를 입력하면 안 됩니다.",
>   "validErrors": null
> }

  - 거절임에도 거절 사유를 입력하지 않으면 예외 처리 했습니다. 
> {
>   "errorCode": "REJECTION_REASON_REQUIRED",
>   "errorMessage": "거절일 경우, 거절 사유는 필수입니다.",
>   "validErrors": null
> } 