### PR TITLE
refactor : 누락된 유효성 검사 추가 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/dto/CommentDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/board/dto/CommentDTO.java
@@ -1,6 +1,7 @@
 package community.ddv.domain.board.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,6 +13,7 @@ public class CommentDTO {
   public static class CommentRequestDto {
 
     @NotBlank(message = "댓글 내용을 작성해주세요.")
+    @Size(max = 500, message = "댓글은 500자 이하로만 쓸 수 있습니다.")
     private String content;
 
   }

--- a/ddv/src/main/java/community/ddv/domain/board/dto/ReviewDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/board/dto/ReviewDTO.java
@@ -2,6 +2,7 @@ package community.ddv.domain.board.dto;
 
 import community.ddv.domain.board.custom.RatingValid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,9 +14,11 @@ public class ReviewDTO {
   private Long tmdbId;
 
   @NotBlank(message = "제목을 작성해주세요")
+  @Size(max = 60, message = "제목은 60자 이하로 작성해주세요")
   private String title;
 
   @NotBlank(message = "내용을 작성해주세요")
+  @Size(max = 10000, message = "내용은 10000자 이하로 작성해주세요")
   private String content;
 
   @RatingValid
@@ -27,7 +30,10 @@ public class ReviewDTO {
   @AllArgsConstructor
   public static class ReviewUpdateDTO {
 
+    @Size(max = 60, message = "제목은 60자 이하로 작성해주세요")
     private String title;
+
+    @Size(max = 10000, message = "내용은 10000자 이하로 작성해주세요")
     private String content;
 
     @RatingValid

--- a/ddv/src/main/java/community/ddv/domain/board/entity/Review.java
+++ b/ddv/src/main/java/community/ddv/domain/board/entity/Review.java
@@ -48,7 +48,7 @@ public class Review {
 
   private String title; // 제목
 
-  @Column(length = 1000)
+  @Column(length = 10000)
   private String content; // 내용 (1000자 이내로 제한)
 
   private Double rating; // 별점

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -60,30 +60,9 @@ public class NotificationService {
     // 초기 메시지 전송
     sendFirstMessage(userId, newEmitter);
 
-//    newEmitter.onCompletion(() -> {
-//      SseEmitter current = emitters.get(userId);
-//      if (current == newEmitter) {
-//        emitters.remove(userId);
-//        log.debug("SSE 연결 종료 : userId = {}", userId);
-//      }
-//    });
-//
-//    newEmitter.onTimeout(() -> {
-//      SseEmitter current = emitters.get(userId);
-//      if (current == newEmitter) {
-//        emitters.remove(userId);
-//        log.debug("SSE 연결 타임아웃 : userId = {}", userId);
-//      }
-//    });
-//
-
     newEmitter.onCompletion(() -> removeEmitter(userId, newEmitter, "SSE 연결종료"));
     newEmitter.onTimeout(() -> removeEmitter(userId, newEmitter, "SSE 타임아웃"));
-    newEmitter.onError((e) -> {
-      log.error("SSE 연결 에러 발생 : userId = {}, error = {}", userId, e.getMessage());
-      //emitters.remove(userId);
-      removeEmitter(userId, newEmitter, "SSE 연결 에러");
-    });
+    newEmitter.onError((e) -> removeEmitter(userId, newEmitter, "SSE 연결 에러"));
 
     log.info("SSE 구독 완료: userId = {}, 현재 emitter 수 = {}", userId, emitters.size());
     return newEmitter;

--- a/ddv/src/main/java/community/ddv/domain/user/service/AuthService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/AuthService.java
@@ -1,8 +1,5 @@
 package community.ddv.domain.user.service;
 
-import community.ddv.domain.board.repository.CommentRepository;
-import community.ddv.domain.board.repository.ReviewRepository;
-import community.ddv.domain.certification.CertificationRepository;
 import community.ddv.domain.notification.NotificationService;
 import community.ddv.domain.user.constant.Role;
 import community.ddv.domain.user.dto.SignDto.AccountDeleteDto;

--- a/ddv/src/main/java/community/ddv/domain/user/service/AuthService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/AuthService.java
@@ -170,7 +170,10 @@ public class AuthService {
     // SecurityContext 초기화
     SecurityContextHolder.clearContext();
     log.info("SecurityContext 초기화");
+
     notificationService.disconnectEmitter(user.getId());
+    log.info("SSE 연결 종료(로그아웃) : userId = {}", user.getId());
+
 
     log.info("로그아웃 성공");
   }
@@ -244,6 +247,7 @@ public class AuthService {
     log.info("리프레시 토큰 삭제");
 
     notificationService.disconnectEmitter(user.getId());
+    log.info("SSE 연결 종료(회원탈퇴) : userId = {}", user.getId());
     // 사용자 삭제
     userRepository.delete(user);
     log.info("회원탈퇴 완료");


### PR DESCRIPTION
# [변경사항]

1. 리뷰 제목, 내용의 글자 제한 유효성 검사를 추가했습니다. 
제목은 60자 이하, 내용은 10000자 이하로 작성 가능합니다. 

2. 댓글의 글자 제한 유효성 검사를 추가했습니다. 
댓글은 500자 이하로 작성 가능합니다. 

3. Review 엔티티 컬럼 속성 1000 -> 10000 으로 수정했습니다. 
 
4. 로그아웃, 회원탈퇴시 SSE 연결이 끊겼다는 로그를 추가했습니다. 
