### PR TITLE
refactor : 모든 서비스 내 로그 보완, UI 테마색 변경에 따라 인증메일 테마색 변경 

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/board/service/CommentService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/CommentService.java
@@ -38,12 +38,14 @@ public class CommentService {
   @Transactional
   public CommentResponseDto createComment(Long reviewId, CommentRequestDto commentRequestDto) {
 
-    log.info("댓글 작성 요청");
     User user = userService.getLoginUser();
+    log.info("[CREATE_COMMENT] 댓글 작성 시도 - reviewId={}, userId={} ", reviewId, user.getId());
 
     Review review = reviewRepository.findById(reviewId)
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
-    log.info("댓글이 달릴 reviewId: {}", review.getId());
+        .orElseThrow(() -> {
+          log.warn("[CREATE_COMMENT] 존재하지 않는 리뷰 - reviewId={}", reviewId);
+          return new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND);
+        });
 
     String filteredContent = forbiddenWordsFilter.filterForbiddenWords(commentRequestDto.getContent());
 
@@ -54,7 +56,7 @@ public class CommentService {
         .build();
 
     Comment newComment = commentRepository.save(comment);
-    log.info("댓글 작성 완료 - 댓글 ID : {}, 리뷰 ID : {}", newComment.getId(), reviewId);
+    log.info("[CREATE_COMMENT] 댓글 작성 완료 - commentId={}, reviewId={}, userId={}", newComment.getId(), reviewId, user.getId());
 
     notificationService.commentAdded(user.getId(), reviewId);
 
@@ -65,18 +67,24 @@ public class CommentService {
   @Transactional
   public CommentResponseDto updateComment(Long reviewId, Long commentId, CommentRequestDto commentRequestDto) {
 
-    log.info("댓글 수정 요청 - 댓글 ID : {}", commentId);
     User user = userService.getLoginUser();
+    log.info("[UPDATE_COMMENT] 댓글 수정 시도 - commentId={}, reviewId={}, userId={}", commentId, reviewId, user.getId());
 
     reviewRepository.findById(reviewId)
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[UPDATE_COMMENT] 존재하지 않는 리뷰 - reviewId={}", reviewId);
+          return new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND);
+        });
 
     Comment comment = commentRepository.findById(commentId)
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.COMMENT_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[UPDATE_COMMENT] 존재하지 않는 댓글 - commentId={}", commentId);
+          return new DeepdiviewException(ErrorCode.COMMENT_NOT_FOUND);
+        });
 
     // 댓글 작성자만 수정 가능
     if (!comment.getUser().getId().equals(user.getId())) {
-      log.warn("댓글 수정은 작성자만 수정 가능합니다. 작성자 ID : {}, 수정 요청자 ID : {}", comment.getUser().getId(), user.getId());
+      log.warn("[UPDATE_COMMENT] 댓글 수정은 작성자만 수정 가능합니다. 작성자 userId : {}, 수정 요청자 userId : {}", comment.getUser().getId(), user.getId());
       throw new DeepdiviewException(ErrorCode.INVALID_USER);
     }
 
@@ -85,26 +93,32 @@ public class CommentService {
 
     comment.updateContent(filteredContent);
     commentRepository.flush();
-
+    log.info("[UPDATE_COMMENT] 댓글 수정 완료 - commentId={}", commentId);
     return convertToCommentResponse(comment);
   }
 
 
   @Transactional
   public void deleteComment(Long reviewId, Long commentId) {
-    log.info("댓글 삭제 요청 - 댓글 ID : {}, 리뷰 ID : {}", commentId, reviewId);
 
     User user = userService.getLoginUser();
+    log.info("[DELETE_COMMENT] 댓글 삭제 시도 - commentId={}, reviewId={}, userId={}", commentId, reviewId, user.getId());
 
     Review review = reviewRepository.findById(reviewId)
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[DELETE_COMMENT] 존재하지 않는 리뷰 - reviewId={}", reviewId);
+          return new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND);
+        });
 
     Comment comment = commentRepository.findById(commentId)
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.COMMENT_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[DELETE_COMMENT] 존재하지 않는 댓글 - commentId={}", commentId);
+          return new DeepdiviewException(ErrorCode.COMMENT_NOT_FOUND);
+        });
 
     // 댓글 작성자만 삭제 가능
     if (!comment.getUser().getId().equals(user.getId())) {
-      log.warn("댓글 삭제는 작성자만 삭제 가능합니다. - 작성자 ID : {}, 삭제 요청자 ID : {}", comment.getUser().getId(), user.getId());
+      log.warn("[DELETE_COMMENT] 댓글 삭제는 작성자만 삭제 가능합니다. - 작성자 userId : {}, 삭제 요청자 userId : {}", comment.getUser().getId(), user.getId());
       throw new DeepdiviewException(ErrorCode.INVALID_USER);
     }
 
@@ -113,6 +127,8 @@ public class CommentService {
     }
 
     commentRepository.delete(comment);
+    log.info("[DELETE_COMMENT] 댓글 삭제 완료 - commentId={}", commentId);
+
   }
 
 

--- a/ddv/src/main/java/community/ddv/domain/board/service/DiscussionService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/DiscussionService.java
@@ -41,24 +41,24 @@ public class DiscussionService {
     // 1. 인증 상태 확인
     User user = userService.getLoginUser();
     if (!certificationService.isUserCertified(user.getId())) {
-      log.warn("인증되지 않은 사용자 : userId = {}", user.getId());
+      log.warn("[CREATE_DISCUSSION] 인증되지 않은 사용자 - userId = {}", user.getId());
       throw new DeepdiviewException(ErrorCode.NOT_CERTIFIED_YET);
     }
-    log.info("인증 상태 확인 완료 : userId = {}", user.getId());
+    log.info("[CREATE_DISCUSSION] 사용자 인증 상태 확인 완료");
 
     // 2. 지난주 1위를 한 영화인지 확인
     Long lastWeekTopMovieTmdbId = voteService.getLastWeekTopVoteMovie();
     Movie lastWeekTopMovie = movieRepository.findByTmdbId(lastWeekTopMovieTmdbId)
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND));
-    log.info("지난 주 투표 1위 영화 확인 - TMDBId = {}, title = {}", lastWeekTopMovieTmdbId, lastWeekTopMovie.getTitle());
+    log.info("[CREATE_DISCUSSION] 지난주 투표 1위 영화 확인 - tmdbId = {}, title = {}", lastWeekTopMovieTmdbId, lastWeekTopMovie.getTitle());
 
     // 3. 리뷰 작성 가능 기간 확인 (월-토)
     LocalDateTime now = LocalDateTime.now();
     if (now.getDayOfWeek() == DayOfWeek.SUNDAY) {
-      log.warn("일요일은 리뷰 작성 불가");
+      log.warn("[CREATE_DISCUSSION] 일요일에는 리뷰 작성 불가");
       throw new DeepdiviewException(ErrorCode.INVALID_REVIEW_PERIOD);
     }
-    log.info("리뷰 작성 가능 기간 확인 완료");
+    log.info("[CREATE_DISCUSSION] 리뷰 작성 가능 기간 확인 완료");
 
     // 4. 중복 리뷰 확인 -> 기존에 작성한 리뷰가 있으면 수정
     // (사용하지 않는 것으로 수정. 봤던 영화를 또 다시 보고 인증 받고 리뷰를 다시 작성하는 경우가 많이 없을 것으로 판단)

--- a/ddv/src/main/java/community/ddv/domain/board/service/LikeService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/LikeService.java
@@ -47,13 +47,13 @@ public class LikeService {
         .build();
     likeRepository.save(newlike);
     review.increaseLikeCount();
-    log.info("좋아요 성공 (좋아요 +1)");
+    log.info("[LIKE] 좋아요 성공 - userId = {}, reviewId = {}, 총 좋아요 수 = {}", user.getId(), review.getId(), review.getLikeCount());
     notificationService.likeAdded(user.getId(), review.getId());
   }
 
   private void unlike(User user, Review review) {
     likeRepository.deleteByReviewAndUser(review, user);
     review.decreaseLikeCount();
-    log.info("좋아요 취소 (좋아요 -1)");
+    log.info("[UNLIKE] 좋아요 취소 - userId = {}, reviewId = {}, 총 좋아요 수 = {}", user.getId(), review.getId(), review.getLikeCount());
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -159,7 +159,6 @@ public class ReviewService {
    */
   @Transactional(readOnly = true)
   public ReviewResponseDTO getReviewById(Long reviewId) {
-    //Review review = reviewRepository.findById(reviewId)
     Review review = reviewRepository.findWithCommentsById(reviewId)
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
     return convertToReviewResponseDto(review);

--- a/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
+++ b/ddv/src/main/java/community/ddv/domain/board/service/ReviewService.java
@@ -48,12 +48,13 @@ public class ReviewService {
   public ReviewIdResponseDto createReview(ReviewDTO reviewDTO) {
 
     User user = userService.getLoginUser();
+    log.info("[CREATE_REVIEW] 리뷰 작성 시도 - userId={}, tmdbId={}", user.getId(), reviewDTO.getTmdbId());
 
     Movie movie = movieRepository.findByTmdbId(reviewDTO.getTmdbId())
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.MOVIE_NOT_FOUND));
 
     if (reviewRepository.existsByUserAndMovie(user, movie)) {
-      log.warn("리뷰 작성 실패 (이미 리뷰를 작성함) - User Id : {}, TMDB Id: {} ", user.getId(), reviewDTO.getTmdbId());
+      log.warn("[CREATE_REVIEW] 리뷰 작성 실패 (이미 리뷰를 작성함) - userId : {}, tmdbId: {} ", user.getId(), reviewDTO.getTmdbId());
       throw new DeepdiviewException(ErrorCode.ALREADY_COMMITTED_REVIEW);
     }
 
@@ -72,7 +73,7 @@ public class ReviewService {
         .build();
 
     reviewRepository.save(review);
-    log.info("리뷰 작성 성공 - 사용자 ID: {}, 리뷰 ID: {}", user.getId(), review.getId());
+    log.info("[CREATE_REVIEW] 리뷰 작성 성공 - userId: {}, reviewID: {}", user.getId(), review.getId());
     return new ReviewIdResponseDto(review.getId());
   }
 
@@ -84,16 +85,18 @@ public class ReviewService {
   public void deleteReview(Long reviewId) {
 
     User user = userService.getLoginUser();
+    log.info("[DELETE_REVIEW] 리뷰 삭제 시도 - reviewId={}, userId={}", reviewId, user.getId());
 
     Review review = reviewRepository.findById(reviewId)
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
 
     if (!review.getUser().equals(user)) {
-      log.warn("리뷰 삭제 권한 없음 - 리뷰 ID: {}, 삭제 요청 유저 ID: {}, 리뷰 작성자 ID: {}", reviewId, user.getId(),
+      log.warn("[DELETE_REVIEW] 리뷰 삭제 권한 없음 - 리뷰 ID: {}, 삭제 요청자 userId: {}, 리뷰 작성자 userId: {}", reviewId, user.getId(),
           review.getUser().getId());
       throw new DeepdiviewException(ErrorCode.INVALID_USER);
     }
     reviewRepository.delete(review);
+    log.info("[DELETE_REVIEW] 리뷰 삭제 완료 - reviewId={}", reviewId);
   }
 
   /**
@@ -106,12 +109,13 @@ public class ReviewService {
   public ReviewIdResponseDto updateReview(Long reviewId, ReviewUpdateDTO reviewUpdateDTO) {
 
     User user = userService.getLoginUser();
+    log.info("[UPDATE_REVIEW] 리뷰 수정 시도 - reviewId={}, userId={}", reviewId, user.getId());
 
     Review review = reviewRepository.findById(reviewId)
         .orElseThrow(() -> new DeepdiviewException(ErrorCode.REVIEW_NOT_FOUND));
 
     if (!review.getUser().equals(user)) {
-      log.warn("리뷰 수정 권한 없음 - 유저 ID: {}, 리뷰 ID: {}, ", user.getId(), reviewId);
+      log.warn("[UPDATE_REVIEW] 리뷰 수정 권한 없음 - userId: {}, reviewId: {}, ", user.getId(), reviewId);
       throw new DeepdiviewException(ErrorCode.INVALID_USER);
     }
 
@@ -123,7 +127,7 @@ public class ReviewService {
         filteredContent,
         reviewUpdateDTO.getRating()
     );
-    log.info("리뷰 수정 성공 - 리뷰 ID: {}", reviewId);
+    log.info("[UPDATE_REVIEW] 리뷰 수정 완료 - reviewId={}", reviewId);
     return new ReviewIdResponseDto(review.getId());
 
   }

--- a/ddv/src/main/java/community/ddv/domain/movie/service/MovieApiService.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/service/MovieApiService.java
@@ -101,7 +101,7 @@ public class MovieApiService {
 
     // DB에는 있지만 API에서 사라진 영화는 isAvailable = false로 변경
     for (Movie movie : existingMovies.values()) {
-      if (!fetchedTmdbIds.contains(movie.getTmdbId())) {
+      if (!fetchedTmdbIds.contains(movie.getTmdbId()) && movie.isAvailable()) {
         movie.changeAsUnavailable();
         movieRepository.save(movie);
       }

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationController.java
@@ -1,6 +1,5 @@
 package community.ddv.domain.notification;
 
-import community.ddv.domain.notification.dto.NotificationResponseDTO;
 import community.ddv.domain.user.service.UserService;
 import community.ddv.global.response.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationResponseDTO.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationResponseDTO.java
@@ -1,6 +1,5 @@
-package community.ddv.domain.notification.dto;
+package community.ddv.domain.notification;
 
-import community.ddv.domain.notification.NotificationType;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/notification/NotificationService.java
@@ -5,7 +5,6 @@ import community.ddv.domain.board.repository.ReviewRepository;
 import community.ddv.domain.certification.Certification;
 import community.ddv.domain.certification.CertificationRepository;
 import community.ddv.domain.certification.constant.CertificationStatus;
-import community.ddv.domain.notification.dto.NotificationResponseDTO;
 import community.ddv.domain.user.entity.User;
 import community.ddv.domain.user.service.UserService;
 import community.ddv.global.exception.DeepdiviewException;
@@ -95,7 +94,6 @@ public class NotificationService {
       log.error("SSE 초기 메시지 전송 실패: userId = {}, error = {}", userId, e.getMessage());
       emitter.completeWithError(e);
       removeEmitter(userId, emitter, "초기 메시지 전송 실패");
-      //emitters.remove(userId);
     }
   }
 

--- a/ddv/src/main/java/community/ddv/domain/user/service/AuthService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/AuthService.java
@@ -45,26 +45,26 @@ public class AuthService {
    */
   @Transactional
   public void signUp(SignUpDto signUpDto) {
-    log.info("회원가입 시도");
+    log.info("[SIGNUP] 회원가입 시도: email={}", signUpDto.getEmail());
 
     // 이메일 인증여부 확인
     if (!emailService.isVerified(signUpDto.getEmail())) {
-      log.warn("이메일 인증하지 않음");
-      throw new DeepdiviewException(ErrorCode.EMAIL_NOT_VERIFIED);
+      log.warn("[SIGNUP] 이메일 인증하지 않음: {}", signUpDto.getEmail());
+    throw new DeepdiviewException(ErrorCode.EMAIL_NOT_VERIFIED);
     }
     // 같은 이메일로 중복 회원가입 불가
     if (userRepository.existsByEmail(signUpDto.getEmail())) {
-      log.warn("중복 회원가입 불가");
+      log.warn("[SIGNUP] 중복 이메일 회원가입 시도: {}", signUpDto.getEmail());
       throw new DeepdiviewException(ErrorCode.ALREADY_EXIST_MEMBER);
     }
     // 비밀번호 확인 로직 통과 여부
     if (!signUpDto.getPassword().equals(signUpDto.getConfirmPassword())) {
-      log.warn("비밀번호 확인 로직 통과 X");
+      log.warn("[SIGNUP] 비밀번호 확인 로직 통과 X");
       throw new DeepdiviewException(ErrorCode.NOT_MATCHED_PASSWORD);
     }
     // 중복 닉네임 사용불가
     if (userRepository.existsByNickname(signUpDto.getNickname())) {
-      log.warn("중복 닉네임 불가");
+      log.warn("[SIGNUP] 중복 닉네임 사용불가");
       throw new DeepdiviewException(ErrorCode.ALREADY_EXIST_NICKNAME);
     }
 
@@ -78,7 +78,7 @@ public class AuthService {
 
     userRepository.save(user);
     redisStringTemplate.delete("EMAIL_VERIFIED:" + signUpDto.getEmail());
-    log.info("회원가입 완료");
+    log.info("[SIGNUP] 회원가입 성공: userId={}, email={}", user.getId(), user.getEmail());
   }
 
   /**
@@ -86,14 +86,18 @@ public class AuthService {
    * @param loginDto - 이메일, 비밀번호
    */
   public LoginResponseDto logIn(LoginDto loginDto) {
-    log.info("로그인 시도 : {} ", loginDto.getEmail());
+    log.info("[LOGIN] 로그인 시도: email={}", loginDto.getEmail());
 
     // 해당 이메일로 가입된 유저가 존재하는지 확인
     User user = userRepository.findByEmail(loginDto.getEmail())
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.USER_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[LOGIN] 존재하지 않는 사용자: email={}", loginDto.getEmail());
+          return new DeepdiviewException(ErrorCode.USER_NOT_FOUND);
+        });
 
     // 비밀번호 검증
     if (!passwordEncoder.matches(loginDto.getPassword(), user.getPassword())) {
+      log.warn("[LOGIN] 비밀번호 불일치: email={}", loginDto.getEmail());
       throw new DeepdiviewException(ErrorCode.NOT_VALID_PASSWORD);
     }
 
@@ -108,7 +112,7 @@ public class AuthService {
       log.info("유효한 리프레시 토큰 사용");
     }
 
-    log.info("로그인 성공");
+    log.info("[LOGIN] 로그인 성공: userId={}, email={}", user.getId(), user.getEmail());
     return LoginResponseDto.builder()
         .accessToken(accessToken)
         .refreshToken(refreshToken)
@@ -134,19 +138,22 @@ public class AuthService {
   public void logout(HttpServletRequest request) {
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
     String email = auth.getName();
-    log.info("로그아웃 요청");
+    log.info("[LOGOUT] 로그아웃 요청");
 
     // 현재 인증된 사용자 이메일과 요청에 포함된 이메일이 동일한지 확인
     User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.USER_NOT_FOUND));
+        .orElseThrow(() -> {
+          log.warn("[LOGOUT] 존재하지 않는 사용자: email={}", email);
+          return new DeepdiviewException(ErrorCode.USER_NOT_FOUND);
+        });
 
     // 리프레시 토큰 삭제
     Boolean deletedRefreshToken = redisStringTemplate.delete(email);
     // NullPointException 방지를 위해 Boolean 객체 사용
     if (Boolean.TRUE.equals(deletedRefreshToken)) {
-      log.info("리프레시 토큰 삭제 완료");
+      log.info("[LOGOUT] 리프레시 토큰 삭제 완료: email={}", email);
     } else {
-      log.warn("로그아웃 실패");
+      log.warn("[LOGOUT] 리프레시 토큰 삭제 실패: email={}", email);
     }
 
     // 기존의 엑세스토큰은 블랙리스트로 등록
@@ -159,21 +166,20 @@ public class AuthService {
       if (remainTime > 0) {
         // 남은 시간동안 블랙리스트로 등록
         redisStringTemplate.opsForValue().set(accessToken, "logout", remainTime, TimeUnit.MILLISECONDS);
-        log.info("엑세스토큰 블랙리스트로 등록 완료");
+        log.info("[LOGOUT] 엑세스토큰 블랙리스트로 등록 완료");
       } else {
-        log.info("만료된 엑세스 토큰");
+        log.info("[LOGOUT] 만료된 엑세스 토큰");
       }
     }
 
     // SecurityContext 초기화
     SecurityContextHolder.clearContext();
-    log.info("SecurityContext 초기화");
+    log.info("LOGOUT SecurityContext 초기화");
 
     notificationService.disconnectEmitter(user.getId());
-    log.info("SSE 연결 종료(로그아웃) : userId = {}", user.getId());
+    log.info("[LOGOUT] SSE 연결 종료 : userId = {}", user.getId());
 
-
-    log.info("로그아웃 성공");
+    log.info("[LOGOUT] 로그아웃 완료: userId={}, email={}", user.getId(), user.getEmail());
   }
 
   /**
@@ -181,7 +187,7 @@ public class AuthService {
    * @param refreshToken
    */
   public TokenDto reissueAccessToken(String refreshToken) {
-    log.info("리프레시 토큰으로 엑세스 토큰 재발급 요청");
+    log.info("[REISSUE] 리프레시 토큰으로 엑세스 토큰 재발급 요청");
 
     // 리프레시 토큰이 유효한지 확인
     if (!jwtProvider.isTokenValid(refreshToken)) {
@@ -202,7 +208,7 @@ public class AuthService {
     // 새 엑세스 토큰 생성/발급
     String newAccessToken = jwtProvider.generateAccessToken(user.getEmail(), user.getRole());
 
-    log.info("엑세스 토큰 재발급 완료");
+    log.info("[REISSUE] 엑세스 토큰 재발급 완료");
     return new TokenDto(newAccessToken);
   }
 
@@ -214,14 +220,16 @@ public class AuthService {
   public void deleteAccount(AccountDeleteDto accountDeleteDto, HttpServletRequest request) {
 
     User user = userService.getLoginUser();
-    log.info("회원탈퇴 요청 : {}", user.getEmail());
+    log.info("[DELETE_ACCOUNT] 회원탈퇴 요청: userId={}, email={}", user.getId(), user.getEmail());
 
     if (user.getRole() == Role.ADMIN) {
+      log.warn("[DELETE_ACCOUNT] 관리자 탈퇴 차단");
       throw new DeepdiviewException(ErrorCode.ADMIN_CANNOT_BE_DELETED);
     }
 
     // 비밀번호 확인
     if (!passwordEncoder.matches(accountDeleteDto.getPassword(), user.getPassword())) {
+      log.warn("[DELETE_ACCOUNT] 비밀번호 불일치: userId={}, email={}", user.getId(), user.getEmail());
       throw new DeepdiviewException(ErrorCode.NOT_VALID_PASSWORD);
     }
 
@@ -237,21 +245,21 @@ public class AuthService {
         // 남은 시간동안 블랙리스트로 등록
         redisStringTemplate.opsForValue()
             .set(accessToken, "logout", remainTime, TimeUnit.MILLISECONDS);
-        log.info("엑세스 토큰 블랙리스트로 등록 완료");
+        log.info("[DELETE_ACCOUNT] 엑세스 토큰 블랙리스트로 등록 완료");
       }
     }
 
     redisStringTemplate.delete(user.getEmail());
-    log.info("리프레시 토큰 삭제");
+    log.info("[DELETE_ACCOUNT] 리프레시 토큰 삭제");
 
     notificationService.disconnectEmitter(user.getId());
-    log.info("SSE 연결 종료(회원탈퇴) : userId = {}", user.getId());
+    log.info("[DELETE_ACCOUNT] SSE 연결 종료 : userId = {}", user.getId());
     // 사용자 삭제
     userRepository.delete(user);
-    log.info("회원탈퇴 완료");
+    log.info("[DELETE_ACCOUNT] 회원탈퇴 완료: userId={}, email={}", user.getId(), user.getEmail());
 
     SecurityContextHolder.clearContext();
-    log.info("SecurityContext 초기화");
+    log.info("[DELETE_ACCOUNT] SecurityContext 초기화");
   }
 
 }

--- a/ddv/src/main/java/community/ddv/domain/user/service/AuthService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/AuthService.java
@@ -53,7 +53,6 @@ public class AuthService {
       throw new DeepdiviewException(ErrorCode.EMAIL_NOT_VERIFIED);
     }
     // 같은 이메일로 중복 회원가입 불가
-    //if (userRepository.findByEmail(signUpDto.getEmail()).isPresent()) {
     if (userRepository.existsByEmail(signUpDto.getEmail())) {
       log.warn("중복 회원가입 불가");
       throw new DeepdiviewException(ErrorCode.ALREADY_EXIST_MEMBER);
@@ -64,7 +63,6 @@ public class AuthService {
       throw new DeepdiviewException(ErrorCode.NOT_MATCHED_PASSWORD);
     }
     // 중복 닉네임 사용불가
-    //if (userRepository.findByNickname(signUpDto.getNickname()).isPresent()) {
     if (userRepository.existsByNickname(signUpDto.getNickname())) {
       log.warn("중복 닉네임 불가");
       throw new DeepdiviewException(ErrorCode.ALREADY_EXIST_NICKNAME);

--- a/ddv/src/main/java/community/ddv/domain/user/service/EmailService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/EmailService.java
@@ -46,14 +46,14 @@ public class EmailService {
 
   private String buildEmailHTML(String authCode) {
     return """
-        <div style="width: 100%%; text-align: center; font-family: Arial, sans-serif; padding: 20px;">
-          <h2 style="color: #4b4bfc;">[DeepDiview] 가입을 위한 인증 코드 안내</h2>
-          <p>아래 인증 코드를 확인하여 이메일 인증을 완료해주세요</p>
-          <div style="display: inline-block; padding: 15px 30px; background-color: #e0e0ff;
-                      border: 2px solid #5f5dff; border-radius: 10px; margin: 20px;">
-            <span style="font-size: 25px; font-weight: bold; color: #4b4bfc;">%s</span>
+        <div style="width: 100%%;  background-color: #141414; color: #ffffff; text-align: center; font-family: Arial, sans-serif; padding: 20px;">
+          <h2 style="color: #e50914; font-size: 24px; margin-bottom: 20px;">[DeepDiview] 이메일 인증 코드</h2>
+          <p style="font-size: 16px; color: #e0e0e0;">아래 인증 코드를 확인하여 이메일 인증을 완료해주세요.</p>
+          <div style="display: inline-block; padding: 18px 36px; background-color: #333333;
+                      border: 3px solid #e50914; border-radius: 8px; margin: 30px 0;">
+            <span style="font-size: 28px; font-weight: bold; color: #e50914;">%s</span>
           </div>
-          <p>인증 코드는 5분 내에 입력해주세요.</p>
+          <p style="font-size: 14px; color: #e0e0e0;">인증 코드는 5분 내에 입력해주세요.</p>
         </div>
         """.formatted(authCode);
   }

--- a/ddv/src/main/java/community/ddv/domain/user/service/EmailService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/EmailService.java
@@ -52,14 +52,20 @@ public class EmailService {
 
   private String buildEmailHTML(String authCode) {
     return """
-        <div style="width: 100%%;  background-color: #141414; color: #ffffff; text-align: center; font-family: Arial, sans-serif; padding: 20px;">
-          <h2 style="color: #e50914; font-size: 24px; margin-bottom: 20px;">[DeepDiview] 이메일 인증 코드</h2>
-          <p style="font-size: 16px; color: #e0e0e0;">아래 인증 코드를 확인하여 이메일 인증을 완료해주세요.</p>
-          <div style="display: inline-block; padding: 18px 36px; background-color: #333333;
-                      border: 3px solid #e50914; border-radius: 8px; margin: 30px 0;">
+        <div style="width: 100%%; text-align: center; font-family: Arial, sans-serif;">
+          <h2 style="color: #e50914;">
+            [DeepDiview] 이메일 인증 코드
+          </h2>
+          <p>
+            아래 인증 코드를 확인하여 이메일 인증을 완료해주세요.
+          </p>
+          <div style="display: inline-block; padding: 15px; background-color: #000000;
+                      border: 3px solid #e50914; border-radius: 10px; margin: 20px;">
             <span style="font-size: 28px; font-weight: bold; color: #e50914;">%s</span>
           </div>
-          <p style="font-size: 14px; color: #e0e0e0;">인증 코드는 5분 내에 입력해주세요.</p>
+          <p>
+            인증 코드는 5분 내에 입력해주세요.
+          </p>
         </div>
         """.formatted(authCode);
   }

--- a/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
+++ b/ddv/src/main/java/community/ddv/domain/user/service/ProfileImageService.java
@@ -25,6 +25,8 @@ public class ProfileImageService {
   public String updateProfileImage(MultipartFile profileImage) {
 
     User user = userService.getLoginUser();
+    log.info("[PROFILE_IMAGE_UPDATE] 프로필 이미지 등록/수정 시도 - userId = {}", user.getId());
+
     String existingProfileImageUrl = user.getProfileImageUrl();
 
     // 기존 프사가 존재하는 경우, 삭제 후 새 이미지로 대체 (디폴트 프사가 아닐 때!)
@@ -35,7 +37,7 @@ public class ProfileImageService {
 
     String newProfileImageUrl = fileStorageService.uploadFile(profileImage);
     user.updateProfileImageUrl(newProfileImageUrl);
-    log.info("프로필 이미지 등록/수정 완료");
+    log.info("[PROFILE_IMAGE_UPDATE] 새 프로필 이미지 등록/수정 완료 ");
     return newProfileImageUrl;
 
   }
@@ -50,7 +52,7 @@ public class ProfileImageService {
   @Transactional
   public String deleteProfileImage() {
     User user = userService.getLoginUser();
-    log.info("프로필사진 삭제 요청");
+    log.info("[PROFILE_IMAGE_DELETE] 프로필 이미지 삭제 요청 - userId = {}", user.getId());
 
     String profileImageUrl = user.getProfileImageUrl();
     if (profileImageUrl != null && !profileImageUrl.isEmpty()
@@ -59,7 +61,7 @@ public class ProfileImageService {
       fileStorageService.deleteFile(user.getProfileImageUrl());
     }
     user.updateProfileImageUrl(defaultProfileImageUrl);
-    log.info("기본 프로필로 초기화");
+    log.info("[PROFILE_IMAGE_DELETE] 기본 이미지로 변경 완료 - userId = {}", user.getId());
     return defaultProfileImageUrl;
   }
 }

--- a/ddv/src/main/java/community/ddv/domain/vote/service/VoteService.java
+++ b/ddv/src/main/java/community/ddv/domain/vote/service/VoteService.java
@@ -58,7 +58,7 @@ public class VoteService {
 
     // 로그인된 관리자만 투표 생성 가능
     User admin = userService.getLoginUser();
-    log.info("투표 생성 시도");
+    log.info("[CREATE_VOTE] 투표 생성 시도: userId={}", admin.getId());
     if (!admin.getRole().equals(Role.ADMIN)) {
       log.error("관리자만 투표를 생성할 수 있습니다.");
       throw new DeepdiviewException(ErrorCode.ONLY_ADMIN_CAN);
@@ -67,7 +67,7 @@ public class VoteService {
     // 투표 생성은 일요일만 가능, 한 주에 한 번만 가능
     LocalDateTime now = LocalDateTime.now();
     if (now.getDayOfWeek() != DayOfWeek.SUNDAY) {
-      log.error("투표 생성은 일요일만 가능합니다 : 현재요일 = {}", now.getDayOfWeek());
+      log.error("[CREATE_VOTE] 투표 생성은 일요일만 가능 : 현재요일 = {}", now.getDayOfWeek());
       throw new DeepdiviewException(ErrorCode.INVALID_VOTE_CREATE_DATE);
     }
 
@@ -82,7 +82,7 @@ public class VoteService {
 //    boolean voteAlreadyExists = voteRepository.existsByStartDateBetween(thisWeekStart, thisWeekEnd);
 
     if (voteAlreadyExists) {
-      log.error("이미 생성한 투표가 있습니다.");
+      log.error("[CREATE_VOTE] 이미 다음 주에 생성된 투표가 존재함");
       throw new DeepdiviewException(ErrorCode.ALREADY_EXIST_VOTE);
     }
 
@@ -121,7 +121,7 @@ public class VoteService {
     List<Long> tmdbIds = savedVote.getVoteMovies().stream()
         .map(voteMovie -> voteMovie.getMovie().getTmdbId())
         .toList();
-    log.info("투표 생성 완료 : voteId = {}, 시작시간 = {}, 종료시간 = {}", savedVote.getId(), savedVote.getStartDate(), savedVote.getEndDate());
+    log.info("[CREATE_VOTE] 투표 생성 완료 : voteId = {}, 시작시간 = {}, 종료시간 = {}", savedVote.getId(), savedVote.getStartDate(), savedVote.getEndDate());
     return new VoteOptionsDto(tmdbIds);
 
   }
@@ -182,17 +182,20 @@ public class VoteService {
   public VoteResultDTO participateVote(VoteParticipationRequestDto voteParticipationRequestDto) {
 
     User user = userService.getLoginUser();
-    log.info("투표 시도 : userId = {} ", user.getId());
+    log.info("[VOTE] 투표 시도: userId={}", user.getId());
 
     LocalDateTime now = LocalDateTime.now();
     // 현재시간 전에 투표가 시작됐어야 하고, 현재시간 후로도 투표가 진행되고 있는, 즉 끝나지 않은 투표 조회
     Vote vote = voteRepository.findByStartDateBeforeAndEndDateAfter(now, now)
-        .orElseThrow(() -> new DeepdiviewException(ErrorCode.INVALID_VOTE_PERIOD));
+        .orElseThrow(() -> {
+          log.error("[VOTE] 투표 기간이 아님");
+          return new DeepdiviewException(ErrorCode.INVALID_VOTE_PERIOD);
+        });
 
     // 중복참여 불가
     boolean alreadyParticipated = voteParticipationRepository.existsByUserAndVote(user, vote);
     if (alreadyParticipated) {
-      log.error("이미 참여한 사용자");
+      log.warn("[VOTE] 이미 투표에 참여한 사용자: userId={}", user.getId());
       throw new DeepdiviewException(ErrorCode.AlREADY_VOTED);
     }
 
@@ -211,7 +214,7 @@ public class VoteService {
     voteParticipationRepository.save(voteParticipation);
     selectedVotedMovie.plusVoteCount(); // 득표수 증가 & 최종 득표시간 업데이트
 
-    log.info("투표 참여 완료: 사용자 ID = {}, 영화 ID = {}", user.getId(), selectedVotedMovie.getMovie().getTmdbId());
+    log.info("[VOTE] 투표 참여 완료: 사용자 ID = {}, 투표 ID = {}, 영화 ID = {}", user.getId(), vote.getId(), selectedVotedMovie.getMovie().getTmdbId());
     return createVoteResultDto(vote, user.getId());
 
   }

--- a/ddv/src/main/java/community/ddv/global/component/Scheduler.java
+++ b/ddv/src/main/java/community/ddv/global/component/Scheduler.java
@@ -23,9 +23,9 @@ public class Scheduler {
   // 매주 일요일 0시 0분 5초에 영화 데이터 업데이트하면서 인기 영화 목록 캐시 초기화
   @Scheduled(cron = "5 0 0 * * SUN")
   public void updateMovieApi() {
-    log.info("영화정보 업데이트를 시작합니다.");
+    log.info("[SCHEDULER] 영화정보 업데이트를 시작");
     movieApiService.fetchAndSaveMovies();
-    log.info("영화정보 업데이트를 완료했습니다.");
+    log.info("[SCHEDULER] 영화정보 업데이트를 완료");
     clearTopMoviesCache();
   }
 
@@ -34,15 +34,15 @@ public class Scheduler {
     if (top20Cache != null) {
       top20Cache.clear();
     }
-    log.info("인기영화 캐시 초기화 완료");
+    log.info("[SCHEDULER] 인기영화 캐시 초기화 완료");
   }
 
   // 매주 일요일 0시 3분에 런타임 데이터 업데이트
   @Scheduled(cron = "0 3 0 * * SUN")
   public void updateMovieRuntimeApi() {
-    log.info("런타임정보 업데이트를 시작합니다.");
+    log.info("[SCHEDULER] 런타임정보 업데이트를 시작");
     movieApiService.fetchMovieRunTime();
-    log.info("런타임정보 업데이트를 완료했습니다.");
+    log.info("[SCHEDULER] 런타임정보 업데이트를 완료");
   }
 
   // 매주 일요일 0시 0분 0초 지난 주 1위 영화 캐시 초기화
@@ -53,22 +53,24 @@ public class Scheduler {
     if (topVotedCache != null) {
       topVotedCache.clear();
     }
-    log.info("지난 주 1위 영화 캐시 초기화 완료");
+    log.info("[SCHEDULER] 지난 주 1위 영화 캐시 초기화 완료");
   }
 
   // 매주 일요일 0시 2초, 인증상태 초기화 스케줄링
   @Scheduled(cron = "2 0 0 * * SUN")
   public void resetCertificationStatus() {
+    log.info("[SCHEDULER] 새로운 주가 됨에 따라 인증상태 초기화 시작");
     certificationService.resetCertificationStatus();
-    log.info("인증상태 초기화 완료");
+    log.info("[SCHEDULER] 인증 상태 초기화 완료");
+
   }
 
   // 매일 새벽 3시, 31일된 알림 삭제 처리 스케줄링
   @Scheduled(cron = "0 0 3 * * *")
   public void deleteOldNotifications() {
-    log.info("31일 이상 지난 알림 삭제 시작");
+    log.info("[SCHEDULER] 31일 이상 지난 알림 삭제 시작");
     notificationService.deleteOldNotifications();
-    log.info("31일 이상 지난 알림 삭제 완료");
+    log.info("[SCHEDULER] 31일 이상 지난 알림 삭제 완료");
   }
 
 }


### PR DESCRIPTION
# [변경사항]

1. 모든 서비스의 로그를 좀 더 촘촘하게 넣었습니다. 관련된 id들이 함께 나오도록 했으며, prefix로 각 서비스의 이름을 넣었습니다. 다만, 단순한 조회는 로그를 넣지 않았습니다. 
2. UI 테마색이 변경됨에 따라 인증메일의 테마색도 변경했습니다. 다크모드 때문에 background-color는 넣지 않았습니다. 
