### PR TITLE
feat : 영화 검색시, 원어 제목으로도 검색할 수 있도록 추가

### DIFF
--- a/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
+++ b/ddv/src/main/java/community/ddv/domain/certification/CertificationService.java
@@ -203,11 +203,11 @@ public class CertificationService {
     List<Certification> certifications;
     if (status == null) {
       // 전체 조회
-      log.info("인증 전체 조회");
+      log.info("[CERTIFICATION] 인증 전체 조회");
       certifications = certificationRepository.findAllWithCursor(cursorCreatedAt, cursorId, endOfWeek, pageable);
     } else {
       // 인증 상태에 따른 조회
-      log.info("인증 상태에 따른 조회 : status = {}", status);
+      log.info("[CERTIFICATION] 인증 상태에 따른 조회 : status = {}", status);
       certifications = certificationRepository.findByStatusWithCursor(status,cursorCreatedAt, cursorId, endOfWeek, pageable);
     }
 
@@ -266,7 +266,7 @@ public class CertificationService {
       certification.reject(rejectionReason);
       log.info("[CERTIFICATION] 인증 거절 완료 : certificationId = {}, 거절 사유 = {}", certificationId, rejectionReason);
     }
-    log.info("인증 상태 변경 완료 : certificationId = {}, newStatus = {} ", certificationId, certification.getStatus());
+    log.info("[CERTIFICATION] 인증 상태 변경 완료 : certificationId = {}, newStatus = {} ", certificationId, certification.getStatus());
 
     certificationRepository.save(certification);
 
@@ -334,7 +334,7 @@ public class CertificationService {
       try {
         fileStorageService.deleteFile(certification.getCertificationUrl());
       } catch (RuntimeException e) {
-        log.info("인증샷 파일을 S3에서 삭제 실패, url = {}", certification.getCertificationUrl());
+        log.info("[CERTIFICATION] 인증샷 파일을 S3에서 삭제 실패, url = {}", certification.getCertificationUrl());
       }
     }
     certificationRepository.resetAllCertifications();

--- a/ddv/src/main/java/community/ddv/domain/movie/repostitory/MovieRepository.java
+++ b/ddv/src/main/java/community/ddv/domain/movie/repostitory/MovieRepository.java
@@ -29,6 +29,7 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
       SELECT m
       FROM Movie m
       WHERE REPLACE(m.title, ' ', '') LIKE CONCAT('%', REPLACE(:title, ' ', ''), '%')
+      OR REPLACE(m.originalTitle, ' ', '') LIKE CONCAT('%', REPLACE(:title, ' ', ''), '%')
       ORDER BY m.popularity DESC
       """)
   Page<Movie> findByTitleFlexible(@Param("title") String title, Pageable pageable);

--- a/ddv/src/main/java/community/ddv/global/config/SwaggerConfig.java
+++ b/ddv/src/main/java/community/ddv/global/config/SwaggerConfig.java
@@ -14,7 +14,7 @@ public class SwaggerConfig {
     return new OpenAPI()
         .info(new Info()
             .title("DeepDiview")
-            .version("1.0")
+            .version("1.2.145")
             .description("DeepDiview API 명세서"))
         .addServersItem(new Server().url("https://www.deepdiview.site").description("DeepDiview BE Server"));
   }


### PR DESCRIPTION
# [변경사항]

- 이전에는 한글 제목(컬럼명 title)만 검색할 수 있도록 하였으나, originalTitle (원어 제목)으로도 영화 검색이 되도록 쿼리에 조건을 추가했습니다. 
